### PR TITLE
Read image and sources from config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ RUN  apt-get update \
   && apt-get install gcc libgmp3-dev -y \
   && apt-get clean
 WORKDIR /app
-RUN pip install ecdsa fastecdsa sympy cairo-lang pytest pytest-asyncio
+ARG CAIRO_VERSION
+RUN pip install ecdsa fastecdsa sympy cairo-lang==$CAIRO_VERSION

--- a/README.md
+++ b/README.md
@@ -51,26 +51,29 @@ describe("Starknet", function () {
 ## Config
 Specify custom configuration by editing your project's `hardhat.config.js` (or .ts).
 
-### Artifacts path
-- Defaults to `starknet-artifacts`.
-- Has to be different from the value used by `paths.artifacts` (which is `artifacts` by default).
+### Paths
 ```javascript
 module.exports = {
   ...
   paths: {
-    starknetArtifacts: "my-starknet-path"
+    // Defaults to "contracts" (the same as `paths.sources`).
+    starknetSources: "my-own-starknet-path",
+
+    // Defaults to "starknet-artifacts".
+    // Has to be different from the value used by `paths.artifacts` (which is `artifacts` by default).
+    starknetArtifacts: "also-my-own-starknet-path",
   }
   ...
 };
 ```
 
 ### Cairo version
-- Defaults to `latest`.
-- For a list of available versions, check [here](https://hub.docker.com/r/shardlabs/cairo-cli/tags).
+For a list of available versions, check [here](https://hub.docker.com/r/shardlabs/cairo-cli/tags).
 ```javascript
 module.exports = {
   ...
   cairo: {
+    // Defaults to "latest"
     version: "0.4.1"
   }
   ...

--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ npm install @shardlabs/starknet-hardhat-plugin
 ## Use
 This plugin adds the following tasks which target the default source/artifact/test directories of your Hardhat project:
 ### `starknet-compile`
-```shell
+```
 npx hardhat starknet-compile
 ```
 
 ### `starknet-deploy` (with optional flags)
-```shell
+```
 npx hardhat starknet-deploy --starknet-network <NAME> --gateway-url <URL>
 ```
 
 ## Test
 To test Starknet contracts with Mocha, use the regular Hardhat `test` task:
-```shell
+```
 npx hardhat test
 ```
 
@@ -49,15 +49,30 @@ describe("Starknet", function () {
 ```
 
 ## Config
-Specify custom configurations by editing your project's `hardhat.config.js` (or .ts).
+Specify custom configuration by editing your project's `hardhat.config.js` (or .ts).
 
 ### Artifacts path
-- Defaults to `starknet-artifacts`
+- Defaults to `starknet-artifacts`.
 - Has to be different from the value used by `paths.artifacts` (which is `artifacts` by default).
 ```javascript
 module.exports = {
+  ...
   paths: {
     starknetArtifacts: "my-starknet-path"
   }
+  ...
+};
+```
+
+### Cairo version
+- Defaults to `latest`.
+- For a list of available versions, check [here](https://hub.docker.com/r/shardlabs/cairo-cli/tags).
+```javascript
+module.exports = {
+  ...
+  cairo: {
+    version: "0.4.1"
+  }
+  ...
 };
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -rf dist && tsc"
+    "build": "rm -rf dist && tsc",
+    "build-image": "docker build -t shardlabs/cairo-cli --build-arg CAIRO_VERSION=$CAIRO_VERSION ."
   },
   "author": "Shard-Labs",
   "license": "ISC",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,5 @@
 export const PLUGIN_NAME = "Starknet";
 export const ABI_SUFFIX = "_abi.json";
 export const DEFAULT_STARKNET_ARTIFACTS_PATH = "starknet-artifacts";
+export const DOCKER_REPOSITORY = "shardlabs/cairo-cli";
+export const DEFAULT_DOCKER_IMAGE_TAG = "latest";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 
 export const PLUGIN_NAME = "Starknet";
 export const ABI_SUFFIX = "_abi.json";
+export const DEFAULT_STARKNET_SOURCES_PATH = "contracts";
 export const DEFAULT_STARKNET_ARTIFACTS_PATH = "starknet-artifacts";
 export const DOCKER_REPOSITORY = "shardlabs/cairo-cli";
 export const DEFAULT_DOCKER_IMAGE_TAG = "latest";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { HardhatPluginError } from "hardhat/plugins";
 import { ProcessResult } from "@nomiclabs/hardhat-docker";
 import "./type-extensions";
 import { DockerWrapper, StarknetContract } from "./types";
-import { PLUGIN_NAME, ABI_SUFFIX, DEFAULT_STARKNET_ARTIFACTS_PATH } from "./constants";
+import { PLUGIN_NAME, ABI_SUFFIX, DEFAULT_STARKNET_ARTIFACTS_PATH, DEFAULT_DOCKER_IMAGE_TAG, DOCKER_REPOSITORY } from "./constants";
 import { HardhatConfig, HardhatUserConfig } from "hardhat/types";
 
 async function traverseFiles(
@@ -92,8 +92,23 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
     config.paths.starknetArtifacts = newPath;
 });
 
+extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
+    config.cairo = userConfig.cairo;
+    if (!config.cairo) {
+        config.cairo = {
+            version: DEFAULT_DOCKER_IMAGE_TAG
+        };
+    }
+
+    if (!config.cairo.version) {
+        config.cairo.version = DEFAULT_DOCKER_IMAGE_TAG;
+    }
+});
+
 extendEnvironment(hre => {
-    hre.dockerWrapper = new DockerWrapper({ repository: "shardlabs/cairo-cli", tag: "latest" });
+    const repository = DOCKER_REPOSITORY;
+    const tag = hre.config.cairo.version;
+    hre.dockerWrapper = new DockerWrapper({ repository, tag });
 });
 
 task("starknet-compile", "Compiles StarkNet contracts")

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -1,5 +1,9 @@
 import { DockerWrapper, StarknetContract } from "./types";
 
+type CairoConfig = {
+    version: string;
+}
+
 declare module "hardhat/types/config" {
     export interface ProjectPathsUserConfig {
         starknetArtifacts?: string;
@@ -7,6 +11,14 @@ declare module "hardhat/types/config" {
 
     export interface ProjectPathsConfig {
         starknetArtifacts: string;
+    }
+
+    export interface HardhatConfig {
+        cairo: CairoConfig;
+    }
+
+    export interface HardhatUserConfig {
+        cairo: CairoConfig;
     }
 }
 

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -7,10 +7,12 @@ type CairoConfig = {
 declare module "hardhat/types/config" {
     export interface ProjectPathsUserConfig {
         starknetArtifacts?: string;
+        starknetSources?: string;
     }
 
     export interface ProjectPathsConfig {
         starknetArtifacts: string;
+        starknetSources?: string;
     }
 
     export interface HardhatConfig {
@@ -18,7 +20,7 @@ declare module "hardhat/types/config" {
     }
 
     export interface HardhatUserConfig {
-        cairo: CairoConfig;
+        cairo?: CairoConfig;
     }
 }
 


### PR DESCRIPTION
- Allow user to specify the docker image used (e.g. `0.4.0` or `latest`).
- Edit dockerfile to require ARG CAIRO_VERSION.
- Add an npm task for building docker images (requires an env var): `CAIRO_VERSION=0.4.1 npm run build-image`
- Allow user to specify sources path (defaults to `contracts`, same as default for solidity).