### PR TITLE
Add CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+version: 2.1
+
+aliases:
+  - &node-base
+    steps:
+      - checkout
+      - run:
+        name: Install
+        command: npm install
+      - run:
+        name: Build
+        command: npm run build
+      - run:
+        name: Test
+        command: npm run test
+
+jobs:
+  test_node_v12:
+    <<: *node-base
+    docker:
+      - image: circleci/node:12
+  test_node_v14:
+    <<: *node-base
+    docker:
+      - image: circleci/node:14
+  npm_publish:
+    docker:
+      - image: circleci/node:14
+    steps:
+      - checkout
+      - run:
+        name: Publish
+        command: ./scripts/npm-publish.sh
+
+workflows:
+  version: 2.1
+  test_and_publish:
+    jobs:
+      - test_node_v12
+      - test_node_v14
+      - npm_publish:
+        filters:
+          branches:
+            only:
+              - master
+        requires:
+          test_node_v12
+          test_node_v14

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Plugin for using Starknet tools within Hardhat projects",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"No tests yet. Add them!\"",
     "build": "rm -rf dist && tsc",
     "build-image": "docker build -t shardlabs/cairo-cli --build-arg CAIRO_VERSION=$CAIRO_VERSION ."
   },

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+CORE_LOCAL_VERSION=$(jq -r ".version" package.json)
+CORE_NPM_VERSION=$(npm view @shardlabs/starknet-hardhat-plugin dist-tags.latest)
+
+if [ $CORE_LOCAL_VERSION = $CORE_NPM_VERSION ]; then
+  echo "Latest npm version is equal to current package version. Up the version to publish to npm."
+else
+  npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+  npm install
+  npm run build
+  npm publish --verbose --access=public
+fi


### PR DESCRIPTION
- Modeled after sourcify's config.yml with some optimizations:
  - parsing package.json with `jq` (circleci images already have it installed)
  - the publishing job will first check if it's necessary to publish, then set npm auth token, install and build
- Currently there are no tests:
  - they will soon be added (in a different PR)
  - `npm run test` simply calls an `echo` which informs about this
- Pending: `NPM_TOKEN` variable which could be added to [the Shard Labs context](https://app.circleci.com/settings/organization/github/Shard-Labs/contexts/f7f363c6-f101-4ac8-9193-343c88da5fb0).