### PR TITLE
Fix compile path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ npm install @shardlabs/starknet-hardhat-plugin
 This plugin adds the following tasks which target the default source/artifact/test directories of your Hardhat project:
 ### `starknet-compile`
 ```
-npx hardhat starknet-compile [PATH...] [--lib-path "<PATH1>:<PATH2>:..."]
+npx hardhat starknet-compile [PATH...] [--cairo-path "<PATH1>:<PATH2>:..."]
 ```
 If no paths are provided, all Starknet contracts in the default contracts directory are compiled. Paths can be files and directories.
 
-`--lib-path` allows specifying the locations of imported files, if necessary. Separate them with a colon (:), e.g. `--lib-path='path/to/lib1:path/to/lib2'`
+`--cairo-path` allows specifying the locations of imported files, if necessary. Separate them with a colon (:), e.g. `--cairo-path='path/to/lib1:path/to/lib2'`
 
 ### `starknet-deploy` (with optional flags)
 ```

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ npm install @shardlabs/starknet-hardhat-plugin
 This plugin adds the following tasks which target the default source/artifact/test directories of your Hardhat project:
 ### `starknet-compile`
 ```
-npx hardhat starknet-compile [PATH...]
+npx hardhat starknet-compile [PATH...] [--lib-path "<PATH1>:<PATH2>:..."]
 ```
 If no paths are provided, all Starknet contracts in the default contracts directory are compiled. Paths can be files and directories.
+
+`--lib-path` allows specifying the locations of imported files, if necessary. Separate them with a colon (:), e.g. `--lib-path='path/to/lib1:path/to/lib2'`
 
 ### `starknet-deploy` (with optional flags)
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,8 +164,8 @@ task("starknet-compile", "Compiles StarkNet contracts")
         "If no paths are provided, the default contracts directory is traversed."
     )
     .addOptionalParam("libPath",
-        "Additional paths to be used by the compiler as library sources." +
-        "Separate them with colon (:), e.g. --lib-path='path/to/lib1:path/to/lib2'"
+        "Allows specifying the locations of imported files, if necessary.\n" +
+        "Separate them with a colon (:), e.g. --lib-path='path/to/lib1:path/to/lib2'"
     )
     .setAction(async (args, hre) => {
         const docker = await hre.dockerWrapper.getDocker();

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,9 +163,9 @@ task("starknet-compile", "Compiles StarkNet contracts")
         "Each of the provided paths is recursively looked into while searching for compilation artifacts.\n" +
         "If no paths are provided, the default contracts directory is traversed."
     )
-    .addOptionalParam("libPath",
+    .addOptionalParam("cairoPath",
         "Allows specifying the locations of imported files, if necessary.\n" +
-        "Separate them with a colon (:), e.g. --lib-path='path/to/lib1:path/to/lib2'"
+        "Separate them with a colon (:), e.g. --cairo-path='path/to/lib1:path/to/lib2'"
     )
     .setAction(async (args, hre) => {
         const docker = await hre.dockerWrapper.getDocker();
@@ -191,12 +191,12 @@ task("starknet-compile", "Compiles StarkNet contracts")
 
                 const outputPath = path.join(dirPath, `${fileName}.json`);
                 const abiPath = path.join(dirPath, `${fileName}${ABI_SUFFIX}`);
-                const libPath = hre.config.paths.starknetSources + (args.libPath ? ":" + args.libPath : "");
+                const cairoPath = hre.config.paths.starknetSources + (args.cairoPath ? ":" + args.cairoPath : "");
                 const compileArgs = [
                     file,
                     "--output", outputPath,
                     "--abi", abiPath,
-                    "--cairo_path", libPath,
+                    "--cairo_path", cairoPath,
                 ];
 
                 const binds = {
@@ -204,7 +204,7 @@ task("starknet-compile", "Compiles StarkNet contracts")
                     [artifactsPath]: artifactsPath
                 }
 
-                for (const p of libPath.split(":")) {
+                for (const p of cairoPath.split(":")) {
                     binds[p] = p;
                 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,6 +229,6 @@ export class StarknetContract {
      */
     async call(functionName: string, functionArgs: any[] = []): Promise<string> {
         const executed = await this.invokeOrCall("call", functionName, functionArgs);
-        return executed.stdout.toString();
+        return executed.stdout.toString().trimEnd();
     }
 }


### PR DESCRIPTION
- Allow importing custom files; fix #12
- Allow specifying library paths on the command line (new CLI parameter `--cairo-path`).
- Trim whitespace on function call output end.