### PR TITLE
Wait for deployment to be pending; check for tx rejection

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ async function iterativelyCheckStatus(
     if (["PENDING", "ACCEPTED_ONCHAIN"].includes(status)) {
         resolve();
     } else if (["REJECTED"].includes(status)) {
-        reject("Transaction rejected.");
+        reject(new Error("Transaction rejected."));
     } else {
         // Make a recursive call, but with a delay.
         // Local var `arguments` holds what was passed in the current call


### PR DESCRIPTION
- When deploying in mocha tests, the deployment process wasn't waited to turn from RECEIVED to PENDING.
- This was solved by reusing the existing `iterativelyCheckStatus` function. Since it was a method of `StarknetContract`, and deployment is done in `StarknetContractFactory`, the function was moved outside and the code was adapted to be used within both classes.
- Some minor refactoring was done to improve code readability. Existing regex extraction code was organized into:
  - `extractFromResponse`, `extractTxHash` and `extractAddress`
- Now checking for the possibility of REJECTED in the process of iteratively checking the tx status after deploy/invoke