### PR TITLE
Refactor running Starknet commands; Fix devnet interaction on macOS+venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ You would typically use the input feature when deploying a single contract requi
 
 ### `starknet-verify`
 ```
-npx hardhat starknet-verify [--starknet-network <NAME>] [--path PATH/TO/CONTRACT] [--address CONTRACT_ADDRESS]
+npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [--address <CONTRACT_ADDRESS>]
 ```
 
-Queries Voyager to verify `PATH/TO/CONTRACT.cairo` deployed at `CONTRACT_ADDRESS`
+Queries [Voyager](https://voyager.online/) to [verify the contract](https://voyager.online/verifyContract) deployed at `<CONTRACT_ADDRESS>` using the source file at `<PATH>`.
 
 Like in the previous command, this plugin relies on `--starknet-network`, but will default to 'alpha' network in case this parameter is not passed.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ module.exports = {
 ```
 you can use it by calling `npx hardhat starknet-deploy --starknet-network myNetwork`.
 
-The Alpha testnet and mainnet are available by default, you don't need to define them in the config file; just pass them with `--starknet-network alpha` or `--starknet-network alphaMainnet`.
+The Alpha networks are available by default, you don't need to define them in the config file; just pass:
+- `--starknet-network alpha` or `--starknet-network goerli-alpha` for Alpha Testnet (on Goerli)
+- `--starknet-network alpha-mainnet` for Alpha Mainnet
 
 If you're passing constructor arguments, pass them space separated, but as a single string (due to limitations of the plugin system).
 ```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,12 +5,15 @@ export const DEFAULT_STARKNET_SOURCES_PATH = "contracts";
 export const DEFAULT_STARKNET_ARTIFACTS_PATH = "starknet-artifacts";
 export const DOCKER_REPOSITORY = "shardlabs/cairo-cli";
 export const DEFAULT_DOCKER_IMAGE_TAG = "0.6.2";
+
 export const ALPHA_TESTNET = "goerli-alpha";
 export const ALPHA_TESTNET_INTERNALLY = "alpha";
 export const ALPHA_MAINNET = "alpha-mainnet";
+export const ALPHA_MAINNET_INTERNALLY = "alphaMainnet";
 export const DEFAULT_STARKNET_NETWORK = ALPHA_TESTNET_INTERNALLY;
 export const ALPHA_URL = "https://alpha4.starknet.io";
 export const ALPHA_MAINNET_URL = "https://alpha-mainnet.starknet.io";
+
 export const CHECK_STATUS_TIMEOUT = 1000; // ms
 export const LEN_SUFFIX = "_len";
 export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,14 +65,6 @@ function processExecuted(executed: ProcessResult): number {
     return executed.statusCode ? 1 : 0;
 }
 
-function hasCairoExtension(filePath: string) {
-    return path.extname(filePath) === ".cairo";
-}
-
-function isStarknetContract(filePath: string) {
-    return hasCairoExtension(filePath);
-}
-
 function isStarknetCompilationArtifact(filePath: string) {
     const content = fs.readFileSync(filePath).toString();
     let parsed = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,8 +246,9 @@ function getGatewayUrl(args: any, hre: HardhatRuntimeEnvironment): string {
     let networkName: string = args.starknetNetwork || process.env.STARKNET_NETWORK;
     if (isMainnet(networkName)) {
         networkName = ALPHA_MAINNET_INTERNALLY;
+    } else if (isTestnet(networkName)) {
+        networkName = ALPHA_TESTNET_INTERNALLY;
     }
-
     if (gatewayUrl && !networkName) {
         return gatewayUrl;
     }
@@ -327,12 +328,12 @@ task("starknet-deploy", "Deploys Starknet contracts which have been compiled.")
                 hre.starknetWrapper, 
                 gatewayUrl, 
                 gatewayUrl, 
-                () => {
-                    console.log("Deployment transaction " + hash + " status is now at least PENDING");
+                status => {
+                    console.log(`Deployment transaction ${hash} is now ${status}`);
                     resolve();
                 },
-                (error) => {
-                    console.log("Deployment transaction " + hash + " status is REJECTED");
+                error => {
+                    console.log(`Deployment transaction ${hash} is REJECTED`);
                     reject(error);
                 }
             )));

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,7 +297,7 @@ task("starknet-deploy", "Deploys Starknet contracts which have been compiled.")
                 const executed = await hre.starknetWrapper.deploy({
                     contract: file,
                     gatewayUrl,
-                    inputs: args.inputs.split(/\s+/),
+                    inputs: args.inputs ? args.inputs.split(/\s+/) : undefined,
                 });
                 if(args.wait){
                     const execResult = processExecuted(executed);

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ function getFileName(filePath: string) {
 
 /**
  * First deletes the file if it already exists. Then creates an empty file at the provided path.
- * Unlinking/deleting is necessary if user switched from docker to venv
+ * Unlinking/deleting is necessary if user switched from docker to venv.
  * @param filePath the file to be recreated
  */
 function initializeFile(filePath: string) {

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -17,7 +17,7 @@ export interface CompileOptions {
 export interface DeployOptions {
     contract: string,
     gatewayUrl: string,
-    inputs: string[],
+    inputs?: string[],
     signature?: string[],
 }
 
@@ -26,8 +26,8 @@ export interface InvokeOrCallOptions {
     address: string,
     abi: string,
     functionName: string,
-    inputs: string[],
-    signature: string[],
+    inputs?: string[],
+    signature?: string[],
     gatewayUrl: string,
     feederGatewayUrl: string,
 }
@@ -57,11 +57,11 @@ export abstract class StarknetWrapper {
             "--gateway_url", options.gatewayUrl,
         ];
 
-        if (options.inputs) {
+        if (options.inputs && options.inputs.length) {
             prepared.push("--inputs", ...options.inputs);
         }
 
-        if (options.signature) {
+        if (options.signature && options.signature.length) {
             prepared.push("--signature", ...options.signature);
         }
 
@@ -80,11 +80,11 @@ export abstract class StarknetWrapper {
             "--address", options.address,
         ];
 
-        if (options.inputs) {
+        if (options.inputs && options.inputs.length) {
             prepared.push("--inputs", ...options.inputs);
         }
 
-        if (options.signature) {
+        if (options.signature && options.signature.length) {
             prepared.push("--signature", ...options.signature);
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface StringMap {
     [key: string]: any;
 }
 
+export type Choice = "call" | "invoke";
 
 function extractFromResponse(response: string, regex: RegExp) {
     const matched = response.match(regex);
@@ -75,16 +76,16 @@ function extractAddress(response: string) {
     tx_status: TxStatus
 }
 
-async function checkStatus(txHash: string, starknetWrapper: StarknetWrapper, gatewayUrl: string, feederGatewayUrl: string): Promise<StatusObject> {
-    const executed = await starknetWrapper.runCommand("starknet", [
-        "tx_status",
-        "--hash", txHash,
-        "--gateway_url", adaptUrl(gatewayUrl),
-        "--feeder_gateway_url", adaptUrl(feederGatewayUrl)
-    ]);
+async function checkStatus(hash: string, starknetWrapper: StarknetWrapper, gatewayUrl: string, feederGatewayUrl: string): Promise<StatusObject> {
+    const executed = await starknetWrapper.getTxStatus({
+        hash,
+        gatewayUrl,
+        feederGatewayUrl
+    });
     if (executed.statusCode) {
         throw new HardhatPluginError(PLUGIN_NAME, executed.stderr.toString());
     }
+
     const response = executed.stdout.toString();
     try {
         const responseParsed = JSON.parse(response);
@@ -151,11 +152,11 @@ function readAbi(abiPath: string): starknet.Abi {
  * @param signature array of transaction signature elements
  * @param starknetArgs destination array
  */
-function handleSignature(signature: Array<Numeric>, starknetArgs: string[]) {
+function handleSignature(signature: Array<Numeric>): string[] {
     if (signature) {
-        starknetArgs.push("--signature");
-        signature.forEach(part => starknetArgs.push(part.toString()));
+        return signature.map(s => s.toString());
     }
+    return [];
 }
 
 export class StarknetContractFactory {
@@ -209,16 +210,12 @@ export class StarknetContractFactory {
      * @returns the newly created instance
      */
     async deploy(constructorArguments?: StringMap, signature?: Array<Numeric>): Promise<StarknetContract> {
-        const starknetArgs = [
-            "deploy",
-            "--contract", this.metadataPath,
-            "--gateway_url", adaptUrl(this.gatewayUrl)
-        ];
-
-        this.handleConstructorArguments(constructorArguments, starknetArgs);
-        handleSignature(signature, starknetArgs);
-
-        const executed = await this.starknetWrapper.runCommand("starknet", starknetArgs, [this.metadataPath]);
+        const executed = await this.starknetWrapper.deploy({
+            contract: this.metadataPath,
+            inputs: this.handleConstructorArguments(constructorArguments),
+            signature: handleSignature(signature),
+            gatewayUrl: this.gatewayUrl,
+        });
         if (executed.statusCode) {
             const msg = "Could not deploy contract. Check the network url in config. Is it responsive?";
             throw new HardhatPluginError(PLUGIN_NAME, msg);
@@ -248,16 +245,16 @@ export class StarknetContractFactory {
         });
     }
 
-    private handleConstructorArguments(constructorArguments: StringMap, starknetArgs: string[]): void {
+    private handleConstructorArguments(constructorArguments: StringMap): string[] {
         if (this.constructorAbi) {
             if (!constructorArguments || Object.keys(constructorArguments).length === 0) {
                 throw new HardhatPluginError(PLUGIN_NAME, "Constructor arguments required but not provided.");
             }
-            const construtorArguments = adaptInput(
+            const argumentArray = adaptInput(
                 this.constructorAbi.name, constructorArguments, this.constructorAbi.inputs, this.abi
             );
-            starknetArgs.push("--inputs");
-            construtorArguments.forEach(arg => starknetArgs.push(arg));
+
+            return argumentArray;
         }
 
         if (constructorArguments && Object.keys(constructorArguments).length) {
@@ -266,6 +263,8 @@ export class StarknetContractFactory {
             }
             // other case already handled
         }
+
+        return [];
     }
 
     /**
@@ -305,7 +304,7 @@ export class StarknetContract {
         this.feederGatewayUrl = config.feederGatewayUrl;
     }
 
-    private async invokeOrCall(kind: "invoke" | "call", functionName: string, args?: StringMap, signature?: Array<Numeric>) {
+    private async invokeOrCall(choice: Choice, functionName: string, args?: StringMap, signature?: Array<Numeric>) {
         if (!this.address) {
             throw new HardhatPluginError(PLUGIN_NAME, "Contract not deployed");
         }
@@ -316,33 +315,22 @@ export class StarknetContract {
             throw new HardhatPluginError(PLUGIN_NAME, msg);
         }
 
-        const starknetArgs = [
-            kind,
-            "--address", this.address,
-            "--abi", this.abiPath,
-            "--function", functionName,
-            "--gateway_url", adaptUrl(this.gatewayUrl),
-            "--feeder_gateway_url", adaptUrl(this.feederGatewayUrl)
-        ];
-
         if (Array.isArray(args)) {
             throw new HardhatPluginError(PLUGIN_NAME, "Arguments should be passed in the form of an object.");
         }
 
-        if (args && Object.keys(args).length) {
-            starknetArgs.push("--inputs");
-            const adapted = adaptInput(functionName, args, func.inputs, this.abi);
-            starknetArgs.push(...adapted);
-        }
-
-        if (signature) {
-            starknetArgs.push("--signature");
-            signature.forEach(part => starknetArgs.push(part.toString()));
-        }
-
-        const executed = await this.starknetWrapper.runCommand("starknet", starknetArgs, [this.abiPath]);
+        const executed = await this.starknetWrapper.invokeOrCall({
+            choice,
+            address: this.address,
+            abi: this.abiPath,
+            functionName: functionName,
+            inputs: adaptInput(functionName, args, func.inputs, this.abi),
+            signature: signature.map(s => s.toString()),
+            gatewayUrl: this.gatewayUrl,
+            feederGatewayUrl: this.feederGatewayUrl
+        });
         if (executed.statusCode) {
-            const msg = `Could not ${kind} ${functionName}:\n` + executed.stderr.toString();
+            const msg = `Could not ${choice} ${functionName}:\n` + executed.stderr.toString();
             const replacedMsg = adaptLog(msg);
             throw new HardhatPluginError(PLUGIN_NAME, replacedMsg);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,12 +110,12 @@ export async function iterativelyCheckStatus(
     starknetWrapper: StarknetWrapper,
     gatewayUrl: string,
     feederGatewayUrl: string,
-    resolve: () => void,
+    resolve: (status: string) => void,
     reject: (reason?: any) => void
 ) {
     const statusObject = await checkStatus(txHash, starknetWrapper, gatewayUrl, feederGatewayUrl);
     if (isTxAccepted(statusObject)) {
-        resolve();
+        resolve(statusObject.tx_status);
     } else if (isTxRejected(statusObject)) {
         reject(new Error("Transaction rejected."));
     } else {
@@ -356,7 +356,7 @@ export class StarknetContract {
                 this.starknetWrapper,
                 this.gatewayUrl,
                 this.feederGatewayUrl,
-                resolve,
+                status => resolve(),
                 reject
             );
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as starknet from "./starknet-types";
 import { HardhatPluginError } from "hardhat/plugins";
 import { PLUGIN_NAME, CHECK_STATUS_TIMEOUT } from "./constants";
-import { adaptLog, adaptUrl } from "./utils";
+import { adaptLog } from "./utils";
 import { adaptInput, adaptOutput } from "./adapt";
 import { StarknetWrapper } from "./starknet-wrappers";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,7 +325,7 @@ export class StarknetContract {
             abi: this.abiPath,
             functionName: functionName,
             inputs: adaptInput(functionName, args, func.inputs, this.abi),
-            signature: signature.map(s => s.toString()),
+            signature: handleSignature(signature),
             gatewayUrl: this.gatewayUrl,
             feederGatewayUrl: this.feederGatewayUrl
         });


### PR DESCRIPTION
## Usage
- Fix path documentation for `starknet-verify`.
- Support different mainnet namings (so far only `alphaMainnet` was supported, now `alpha-mainnet` is also).

## Dev
- Refactor `StarknetWrapper.runCommand` to: `compile`, `deploy`, `getTxStatus`, `invokeOrCall`.
- Make the macOS localhost adaptations only in `DockerWrapper`:
  - Interacting with `starknet-devnet` on macOS using `venv` is now fixed (@octate please approve this PR if you find this to be true).
  - Closes #27