### PR TITLE
Deploy logging and consistent await

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you've used Hardhat 👷‍♀️👷‍♂️ and want to develop for Starknet <img src="https://starkware.co/wp-content/uploads/2021/07/Group-177.svg" alt="starknet" width="18"/>, this plugin might come in hand. If you've never set up a Hardhat project, check out [this guide](https://hardhat.org/tutorial/creating-a-new-hardhat-project.html).
 
-## Content
+## Contents
 - [Install](#install)
 - [CLI commands](#cli-commands)
 - [API](#api)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -51,7 +51,7 @@ function iterate_dir(){
     echo "Finished tests on $network"
 }
 
-if [ "$CIRCLE_BRANCH" == "master" ]; then
+if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$OSTYPE" == "linux-gnu"* ]]; then
     iterate_dir alpha
 fi
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,7 @@ export const DEFAULT_STARKNET_NETWORK = ALPHA_TESTNET_INTERNALLY;
 export const ALPHA_URL = "https://alpha4.starknet.io";
 export const ALPHA_MAINNET_URL = "https://alpha-mainnet.starknet.io";
 
-export const CHECK_STATUS_TIMEOUT = 1000; // ms
+export const CHECK_STATUS_TIMEOUT = 2000; // ms
 export const LEN_SUFFIX = "_len";
 export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";
 export const VOYAGER_MAINNET_CONTRACT_API_URL = "https://voyager.online/api/contract/";

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -70,7 +70,7 @@ export abstract class StarknetWrapper {
 
     public abstract deploy(options: DeployOptions): Promise<ProcessResult>;
 
-    protected prepareInvokeOrCalOptions(options: InvokeOrCallOptions): string[] {
+    protected prepareInvokeOrCallOptions(options: InvokeOrCallOptions): string[] {
         const prepared = [
             options.choice,
             "--abi", options.abi,
@@ -172,7 +172,8 @@ export class DockerWrapper extends StarknetWrapper {
         const preparedOptions = this.prepareCompileOptions(options);
 
         const docker = await this.getDocker();
-        return docker.runContainer(this.image, ["starknet-compile", ...preparedOptions], dockerOptions);
+        const executed = await docker.runContainer(this.image, ["starknet-compile", ...preparedOptions], dockerOptions);
+        return executed;
     }
 
     public async deploy(options: DeployOptions): Promise<ProcessResult> {
@@ -189,7 +190,8 @@ export class DockerWrapper extends StarknetWrapper {
         const preparedOptions = this.prepareDeployOptions(options);
 
         const docker = await this.getDocker();
-        return docker.runContainer(this.image, ["starknet", ...preparedOptions], dockerOptions);
+        const executed = await docker.runContainer(this.image, ["starknet", ...preparedOptions], dockerOptions);
+        return executed;
     }
 
     public async invokeOrCall(options: InvokeOrCallOptions): Promise<ProcessResult> {
@@ -204,10 +206,11 @@ export class DockerWrapper extends StarknetWrapper {
 
         options.gatewayUrl = adaptUrl(options.gatewayUrl);
         options.feederGatewayUrl = adaptUrl(options.feederGatewayUrl);
-        const preparedOptions = this.prepareInvokeOrCalOptions(options);
+        const preparedOptions = this.prepareInvokeOrCallOptions(options);
 
         const docker = await this.getDocker();
-        return docker.runContainer(this.image, ["starknet", ...preparedOptions], dockerOptions);
+        const executed = await docker.runContainer(this.image, ["starknet", ...preparedOptions], dockerOptions);
+        return executed;
     }
 
     public async getTxStatus(options: GetTxStatusOptions): Promise<ProcessResult> {
@@ -221,7 +224,8 @@ export class DockerWrapper extends StarknetWrapper {
         const preparedOptions = this.prepareGetTxStatusOptions(options);
         
         const docker = await this.getDocker();
-        return docker.runContainer(this.image, ["starknet", ...preparedOptions], dockerOptions);
+        const executed = await docker.runContainer(this.image, ["starknet", ...preparedOptions], dockerOptions);
+        return executed;
     }
 }
 
@@ -281,7 +285,7 @@ export class VenvWrapper extends StarknetWrapper {
     }
 
     public async invokeOrCall(options: InvokeOrCallOptions): Promise<ProcessResult> {
-        const preparedOptions = this.prepareInvokeOrCalOptions(options);
+        const preparedOptions = this.prepareInvokeOrCallOptions(options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -42,8 +42,6 @@ function isMainnet(networkName: string): boolean {
         console.error(replacedErr);
     }
 
-    const finalMsg = executed.statusCode ? "Failed" : "Succeeded";
-    console.log(`\t${finalMsg}\n`);
     return executed.statusCode ? 1 : 0;
 }
 
@@ -200,7 +198,7 @@ export async function starknetDeployAction(args: any, hre: HardhatRuntimeEnviron
     }
 
     if (args.wait) { // If the "wait" flag was passed as an argument, check the previously stored transaction hashes for their statuses
-        console.log("Checking deployment transactions...");
+        console.log("Checking deployment transaction...");
         const promises = txHashes.map(hash => new Promise<void>((resolve, reject) => iterativelyCheckStatus(
             hash,
             hre.starknetWrapper,

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -29,7 +29,7 @@ function isMainnet(networkName: string): boolean {
  * @param executed The process result of running the container
  * @returns 0 if succeeded, 1 otherwise
  */
- function processExecuted(executed: ProcessResult): number {
+ function processExecuted(executed: ProcessResult, logStatus: boolean): number {
     
     if (executed.stdout.length) {
         console.log(adaptLog(executed.stdout.toString()));
@@ -42,6 +42,11 @@ function isMainnet(networkName: string): boolean {
         console.error(replacedErr);
     }
 
+    if (logStatus) {
+        const finalMsg = executed.statusCode ? "Failed" : "Succeeded";
+        console.log(`\t${finalMsg}\n`);
+    }
+    
     return executed.statusCode ? 1 : 0;
 }
 
@@ -151,7 +156,7 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
                 cairoPath,
             });
 
-            statusCode += processExecuted(executed);
+            statusCode += processExecuted(executed,true);
         }
     }
 
@@ -185,20 +190,20 @@ export async function starknetDeployAction(args: any, hre: HardhatRuntimeEnviron
                 inputs: args.inputs ? args.inputs.split(/\s+/) : undefined,
             });
             if (args.wait) {
-                const execResult = processExecuted(executed);
+                const execResult = processExecuted(executed,false);
                 if (execResult == 0) {
                     txHashes.push(extractTxHash(executed.stdout.toString()));
                 }
                 statusCode += execResult;
             }
             else {
-                statusCode += processExecuted(executed);
+                statusCode += processExecuted(executed,true);
             }
         }
     }
 
     if (args.wait) { // If the "wait" flag was passed as an argument, check the previously stored transaction hashes for their statuses
-        console.log("Checking deployment transaction...");
+        console.log(`Checking deployment transaction${txHashes.length === 1 ? "" : "s"}...`);
         const promises = txHashes.map(hash => new Promise<void>((resolve, reject) => iterativelyCheckStatus(
             hash,
             hre.starknetWrapper,


### PR DESCRIPTION
- Changed how status messages are logged in"processExecuted".

- Added "await" to all promise returns that didn't have it in StarknetWrapper.

- Increased status check timeout to 2 seconds.

- Updated README.

- Changed testing so that alpha network is only tested on linux machines in CircleCI. 