### PR TITLE
Added check for number of arguments and nested objects' members

### DIFF
--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -134,8 +134,8 @@ function adaptComplexInput(input: any, inputSpec: starknet.Argument, abi: starkn
 
         const memberTypes = type.slice(1, -1).split(", ");
 
-        if (input.length != 2) {
-            const msg = `Expected "${inputSpec.name}" to have exactly 2 arguments`;
+        if (input.length != memberTypes.length) {
+            const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${memberTypes.length === 1 ? "" : "s"}, got ${input.length}.`;
             throw new HardhatPluginError(PLUGIN_NAME, msg);
         }
 
@@ -163,7 +163,7 @@ function adaptComplexInput(input: any, inputSpec: starknet.Argument, abi: starkn
     const inputLen = Object.keys(input || {}).length; 
 
     if(expectedInputCount != inputLen) {
-        const msg = `"${inputSpec.name}": Expected ${expectedInputCount} argument${expectedInputCount === 1 ? "" : "s"}, got ${inputLen}.`;
+        const msg = `"${inputSpec.name}": Expected ${expectedInputCount} member${expectedInputCount === 1 ? "" : "s"}, got ${inputLen}.`;
         throw new HardhatPluginError(PLUGIN_NAME, msg);
     }
 

--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -41,6 +41,22 @@ export function adaptInput(functionName: string, input: any, inputSpecs: starkne
     const adapted: string[] = [];
     let lastSpec: starknet.Argument = { type: null, name: null };
 
+    // User won't pass array length as an argument, so subtract the number of array elements to the expected amount of arguments
+    const countArrays = inputSpecs.filter( i => i.name.endsWith(LEN_SUFFIX)).length;
+    const expectedInputCount = inputSpecs.length-countArrays;
+
+    if(expectedInputCount > 0 && !input) {
+        const msg = `${functionName}: Expected ${expectedInputCount} argument${expectedInputCount === 1 ? "" : "s"}, got 0.`;
+        throw new HardhatPluginError(PLUGIN_NAME, msg);
+    } else if (input) {
+        const inputLength = Object.keys(input).length;
+        
+        if (inputLength != expectedInputCount) {
+            const msg = `${functionName}: Expected ${expectedInputCount} argument${expectedInputCount === 1 ? "" : "s"}, got ${inputLength}.`;
+            throw new HardhatPluginError(PLUGIN_NAME, msg);
+        }
+    }
+
     for (let i = 0; i < inputSpecs.length; ++i) {
         const inputSpec = inputSpecs[i];
         const currentValue = input[inputSpec.name];

--- a/test/general-tests/function-argument-number/check.sh
+++ b/test/general-tests/function-argument-number/check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+npx hardhat starknet-compile contracts/contract.cairo
+npx hardhat test test/function-args-test.ts

--- a/test/general-tests/function-argument-number/hardhat.config.ts
+++ b/test/general-tests/function-argument-number/hardhat.config.ts
@@ -1,0 +1,12 @@
+import "../dist/index.js";
+
+module.exports = {
+    networks: {
+        devnet: {
+            url: "http://localhost:5000"
+        }
+    },
+    mocha: {
+        starknetNetwork: process.env.NETWORK
+    }
+};


### PR DESCRIPTION
Considering the cairo function:
﻿```func foo(a: felt) -> (res: felt):
﻿end```﻿

The following testing code samples with incorrect number of arguments should fail
```
contract.call("foo", { a: 1, b: 2 });
contract.call("foo"); 
```

In functions that take arrays as arguments, the array length is not considered as an argument.