### PR TITLE
Parse negative hexadecimal outputs to BigInt

### DIFF
--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -185,7 +185,8 @@ export function adaptOutput(rawResult: string, outputSpecs: starknet.Argument[],
     const splitStr = rawResult.split(" ");
     const result: bigint[] = [];
     for (const num of splitStr) {
-        result.push(BigInt(num));
+        const parsed = num[0] === '-' ? BigInt(num.substring(1)) * BigInt(-1) : BigInt(num);
+        result.push(parsed);
     }
 
     let resultIndex = 0;


### PR DESCRIPTION
StarkNet calls will return negative numbers (ex. `-0x001`) but `BigInt` can't parse negative hexadecimal strings (`BigInt("-0x001")` will fail with `Cannot convert -0x001 to a BigInt`). `BigInt` will happily parse both `-0x001` (not as a string) and `"0x001"` (positive value as a string).

This change simply strips the sign off, converts the (now positive) hexadecimal value to `BigInt` and negates before returning.