### PR TITLE
Multiple sources paths, rejected transaction error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ module.exports = {
     // Defaults to "starknet-artifacts".
     // Has to be different from the value set in `paths.artifacts` (which is used by core Hardhat and has a default value of `artifacts`).
     starknetArtifacts: "also-my-own-starknet-path",
+
+   // Same purpose as the `--cairo-path` argument on for the `starknet-compile` command
+   // Allows specifying the locations of imported files, if necessary.
+    cairoPaths: ["cairo-path1", "cairo-path2"]
   }
   ...
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,7 @@ task("starknet-verify", "Verifies the contract in the Starknet network.")
     .setAction(starknetVoyagerAction);
 
 task("starknet-invoke", "Invokes a function on a contract in the provided address.")
+    .addFlag("wait", "Wait for invoke transaction to be at least ACCEPTED_ON_L2")
     .addOptionalParam("starknetNetwork", "The network version to be used (e.g. alpha)")
     .addOptionalParam("gatewayUrl", `The URL of the gateway to be used (e.g. ${ALPHA_URL})`)
     .addParam("contract", "The name of the contract to invoke from")

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -117,7 +117,7 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
         }
         checkSourceExists(sourcesPath);
         const files = await traverseFiles(sourcesPath, "*.cairo");
-        const defaultSourcesPaths = defaultSourcesPath.replace(" ", ":");
+        const defaultSourcesPaths = defaultSourcesPath.replace(/\s+/g, " ").replace(" ", ":");
         for (const file of files) {
             console.log("Compiling", file);
             const suffix = file.replace(rootRegex, "");

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -332,6 +332,26 @@ async function starknetInvokeOrCallAction(choice: Choice, args: any, hre: Hardha
         const replacedMsg = adaptLog(msg);
         throw new HardhatPluginError(PLUGIN_NAME, replacedMsg);
     }
+
+    if (choice === "invoke" && args.wait) { // If the "wait" flag was passed as an argument, check the transaction hash for its status
+        console.log(`Checking ${choice} transaction...`);
+        const executedOutput = executed.stdout.toString();
+        const txHash = extractTxHash(executedOutput);
+        await new Promise<void>((resolve, reject) => iterativelyCheckStatus(
+            txHash,
+            hre.starknetWrapper,
+            gatewayUrl,
+            gatewayUrl,
+            status => {
+                console.log(`Invoke transaction ${txHash} is now ${status}`);
+                resolve();
+            },
+            error => {
+                console.log(`Invoke transaction ${txHash} is REJECTED`);
+                reject(error);
+            }
+        ));
+    }
 }
 
 export async function starknetDeployAccountAction(args: any, hre: HardhatRuntimeEnvironment) {

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -112,13 +112,12 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
 
     let statusCode = 0;
     for (let sourcesPath of sourcesPaths) {
-        let basePath = path.parse(sourcesPath).dir;
         if (!path.isAbsolute(sourcesPath)) {
             sourcesPath = path.normalize(path.join(root, sourcesPath));
-            basePath = path.normalize(path.join(root, basePath));
         }
         checkSourceExists(sourcesPath);
         const files = await traverseFiles(sourcesPath, "*.cairo");
+        const defaultSourcesPaths = defaultSourcesPath.replace(" ",":");
         for (const file of files) {
             console.log("Compiling", file);
             const suffix = file.replace(rootRegex, "");
@@ -126,7 +125,7 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
             const dirPath = path.join(artifactsPath, suffix);
             const outputPath = path.join(dirPath, `${fileName}.json`);
             const abiPath = path.join(dirPath, `${fileName}${ABI_SUFFIX}`);
-            const cairoPath = (basePath + ":" + root) + (args.cairoPath ? ":" + args.cairoPath : "");
+            const cairoPath = (defaultSourcesPaths + ":" + root) + (args.cairoPath ? ":" + args.cairoPath : "");
 
             fs.mkdirSync(dirPath, { recursive: true });
             initializeFile(outputPath);

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -117,7 +117,7 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
         }
         checkSourceExists(sourcesPath);
         const files = await traverseFiles(sourcesPath, "*.cairo");
-        const defaultSourcesPaths = defaultSourcesPath.replace(" ",":");
+        const defaultSourcesPaths = defaultSourcesPath.replace(" ", ":");
         for (const file of files) {
             console.log("Compiling", file);
             const suffix = file.replace(rootRegex, "");

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -112,9 +112,10 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
 
     let statusCode = 0;
     for (let sourcesPath of sourcesPaths) {
-        const basePath = path.parse(sourcesPath).dir;
+        let basePath = path.parse(sourcesPath).dir;
         if (!path.isAbsolute(sourcesPath)) {
             sourcesPath = path.normalize(path.join(root, sourcesPath));
+            basePath = path.normalize(path.join(root, basePath));
         }
         checkSourceExists(sourcesPath);
         const files = await traverseFiles(sourcesPath, "*.cairo");

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -112,6 +112,7 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
 
     let statusCode = 0;
     for (let sourcesPath of sourcesPaths) {
+        const basePath = path.parse(sourcesPath).dir;
         if (!path.isAbsolute(sourcesPath)) {
             sourcesPath = path.normalize(path.join(root, sourcesPath));
         }
@@ -124,7 +125,7 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
             const dirPath = path.join(artifactsPath, suffix);
             const outputPath = path.join(dirPath, `${fileName}.json`);
             const abiPath = path.join(dirPath, `${fileName}${ABI_SUFFIX}`);
-            const cairoPath = (sourcesPath + ":" + root) + (args.cairoPath ? ":" + args.cairoPath : "");
+            const cairoPath = (basePath + ":" + root) + (args.cairoPath ? ":" + args.cairoPath : "");
 
             fs.mkdirSync(dirPath, { recursive: true });
             initializeFile(outputPath);

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -363,7 +363,7 @@ async function starknetInvokeOrCallAction(choice: Choice, args: any, hre: Hardha
                 resolve();
             },
             error => {
-                console.log(`Invoke transaction ${txHash} is REJECTED`);
+                console.error(`Invoke transaction ${txHash} is REJECTED`);
                 reject(error);
             }
         ));

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -107,7 +107,7 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
     const rootRegex = new RegExp("^" + root);
 
     const defaultSourcesPath = hre.config.paths.starknetSources;
-    const sourcesPaths: string[] = args.paths || [defaultSourcesPath];
+    const sourcesPaths: string[] = args.paths || defaultSourcesPath.split(" ");
     const artifactsPath = hre.config.paths.starknetArtifacts;
 
     let statusCode = 0;
@@ -115,7 +115,6 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
         if (!path.isAbsolute(sourcesPath)) {
             sourcesPath = path.normalize(path.join(root, sourcesPath));
         }
-
         checkSourceExists(sourcesPath);
         const files = await traverseFiles(sourcesPath, "*.cairo");
         for (const file of files) {
@@ -125,7 +124,7 @@ export async function starknetCompileAction(args: any, hre: HardhatRuntimeEnviro
             const dirPath = path.join(artifactsPath, suffix);
             const outputPath = path.join(dirPath, `${fileName}.json`);
             const abiPath = path.join(dirPath, `${fileName}${ABI_SUFFIX}`);
-            const cairoPath = (defaultSourcesPath + ":" + root) + (args.cairoPath ? ":" + args.cairoPath : "");
+            const cairoPath = (sourcesPath + ":" + root) + (args.cairoPath ? ":" + args.cairoPath : "");
 
             fs.mkdirSync(dirPath, { recursive: true });
             initializeFile(outputPath);

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -22,11 +22,13 @@ declare module "hardhat/types/config" {
     export interface ProjectPathsUserConfig {
         starknetArtifacts?: string;
         starknetSources?: string;
+        cairoPaths?: string[];
     }
 
     export interface ProjectPathsConfig {
         starknetArtifacts: string;
         starknetSources?: string;
+        cairoPaths?: string[];
     }
 
     export interface HardhatConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export function extractTxHash(response: string) {
     return extractFromResponse(response, /^Transaction hash: (.*)$/m);
 }
 
-export function extractAddress(response: string) {
+function extractAddress(response: string) {
     return extractFromResponse(response, /^Contract address: (.*)$/m);
 }
 
@@ -383,7 +383,7 @@ export class StarknetContract {
                 this.feederGatewayUrl,
                 () => resolve(),
                 error => {
-                    console.log(`Invoke transaction ${txHash} is REJECTED.\n` + error.message);
+                    console.error(`Invoke transaction ${txHash} is REJECTED.\n` + error.message);
                     reject(error);
                 }
             );

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,8 @@ function extractAddress(response: string) {
  */
  type StatusObject = {
     block_hash: string,
-    tx_status: TxStatus
+    tx_status: TxStatus,
+    error_message?: string
 }
 
 async function checkStatus(hash: string, starknetWrapper: StarknetWrapper, gatewayUrl: string, feederGatewayUrl: string): Promise<StatusObject> {
@@ -119,7 +120,7 @@ export async function iterativelyCheckStatus(
     if (isTxAccepted(statusObject)) {
         resolve(statusObject.tx_status);
     } else if (isTxRejected(statusObject)) {
-        reject(new Error("Transaction rejected."));
+        reject(new Error("Transaction rejected.\n" + statusObject.error_message));
     } else {
         // Make a recursive call, but with a delay.
         // Local var `arguments` holds what was passed in the current call


### PR DESCRIPTION
- Multiple paths are allowed now for `hardhat.config` file.
- Error message from a rejected transaction now displayed.