### PR TITLE
Update linter (no-unused-vars, semi-spacing, block-spacing)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,10 @@
             "error",
             "never"
         ],
+        "block-spacing": [
+            "error",
+            "always"
+        ],
         "brace-style": [
             "error",
             "1tbs"
@@ -79,6 +83,13 @@
             "error",
             "always"
         ],
+        "semi-spacing": [
+            "error",
+            {
+                "before": false,
+                "after": true
+            }
+        ],
         "space-before-blocks": [
             "error",
             "always"
@@ -97,6 +108,9 @@
         "template-curly-spacing": [
             "error",
             "never"
+        ],
+        "@typescript-eslint/no-unused-vars": [
+            "error"
         ]
     }
 }

--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -260,7 +260,7 @@ function generateComplexOutput(raw: bigint[], rawIndex: number, type: string, ab
             rawIndex = ret.newRawIndex;
         }
 
-    } else {// struct
+    } else { // struct
         if (!(type in abi)) {
             throw new HardhatPluginError(PLUGIN_NAME, `Type ${type} not present in ABI.`);
         }

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -159,9 +159,8 @@ export abstract class StarknetWrapper {
         from argparse import Namespace
         from starkware.starknet.cli.starknet_cli import deploy_account
         asyncio.run(deploy_account(Namespace(${args.join(",")}),[]))`;
-
         script = script.replace(/(?:\r\n|\r|\n)/g, ";");
-        return script ;
+        return script;
 
     }
     public abstract deployAccount(options: DeployAccountOptions): Promise<ProcessResult>;


### PR DESCRIPTION
## Usage
- This PR contains no usage changes.

## Dev
- Enforce `@typescript/no-unused-vars`, `semi-spacing`, `block-spacing` to raise errors in the linting process.