### PR TITLE
Fixed UnhandledPromise error, retry check status on 503

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,8 @@ export const ALPHA_URL = "https://alpha4.starknet.io";
 export const ALPHA_MAINNET_URL = "https://alpha-mainnet.starknet.io";
 
 export const CHECK_STATUS_TIMEOUT = 5000; // ms
+export const CHECK_STATUS_RECOVER_TIMEOUT = 10000; // ms
+
 export const LEN_SUFFIX = "_len";
 export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";
 export const VOYAGER_MAINNET_CONTRACT_API_URL = "https://voyager.online/api/contract/";

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,13 +128,14 @@ export async function iterativelyCheckStatus(
             return undefined;
         });
 
-    if (isTxAccepted(statusObject)) {
+    if (!statusObject) {
+        console.warn("Retrying transaction status check...");
+        // eslint-disable-next-line prefer-rest-params
+        setTimeout(iterativelyCheckStatus, CHECK_STATUS_RECOVER_TIMEOUT, ...arguments);
+    } else if (isTxAccepted(statusObject)) {
         resolve(statusObject.tx_status);
     } else if (isTxRejected(statusObject)) {
         reject(new Error("Transaction rejected. Error message:\n\n" + statusObject.tx_failure_reason.error_message));
-    } else if (statusObject==undefined) {
-        // eslint-disable-next-line prefer-rest-params
-        setTimeout(iterativelyCheckStatus, CHECK_STATUS_RECOVER_TIMEOUT, ...arguments);
     } else {
         // Make a recursive call, but with a delay.
         // Local var `arguments` holds what was passed in the current call

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,15 +125,7 @@ export async function iterativelyCheckStatus(
     const statusObject = await checkStatus(txHash, starknetWrapper, gatewayUrl, feederGatewayUrl)
         .catch(reason => {
             console.warn(reason);
-            return {
-                block_hash: undefined,
-                tx_status: undefined,
-                tx_failure_reason: {
-                    code: undefined,
-                    error_message: reason,
-                    tx_id: undefined
-                }
-            };
+            return undefined;
         });
 
     if (isTxAccepted(statusObject)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,18 +122,19 @@ export async function iterativelyCheckStatus(
     resolve: (status: string) => void,
     reject: (reason?: any) => void
 ) {
-    const statusObject = await checkStatus(txHash, starknetWrapper, gatewayUrl, feederGatewayUrl).catch(reason => {
-        console.warn(reason);
-        return {
-            block_hash: undefined,
-            tx_status: undefined,
-            tx_failure_reason: {
-                code: undefined,
-                error_message: reason,
-                tx_id: undefined
-            }
-        };
-    });
+    const statusObject = await checkStatus(txHash, starknetWrapper, gatewayUrl, feederGatewayUrl)
+        .catch(reason => {
+            console.warn(reason);
+            return {
+                block_hash: undefined,
+                tx_status: undefined,
+                tx_failure_reason: {
+                    code: undefined,
+                    error_message: reason,
+                    tx_id: undefined
+                }
+            };
+        });
 
     if (isTxAccepted(statusObject)) {
         resolve(statusObject.tx_status);
@@ -339,7 +340,6 @@ export class StarknetContract {
     }
 
     private async invokeOrCall(choice: Choice, functionName: string, args?: StringMap, signature?: Array<Numeric>, wallet?: Wallet, blockNumber?: string) {
-        console.log(args);
         if (!this.address) {
             throw new HardhatPluginError(PLUGIN_NAME, "Contract not deployed");
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,7 +132,7 @@ export async function iterativelyCheckStatus(
         resolve(statusObject.tx_status);
     } else if (isTxRejected(statusObject)) {
         reject(new Error("Transaction rejected. Error message:\n\n" + statusObject.tx_failure_reason.error_message));
-    } else if (statusObject.tx_status==undefined) {
+    } else if (statusObject==undefined) {
         // eslint-disable-next-line prefer-rest-params
         setTimeout(iterativelyCheckStatus, CHECK_STATUS_RECOVER_TIMEOUT, ...arguments);
     } else {


### PR DESCRIPTION
Fix UnhandledPromise error caused by checking the transaction status;
When transaction status check fails, the call is retried.