### PR TITLE
Introduce breaking changes for 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,21 +253,21 @@ Use this configuration option to select the `cairo-lang`/`starknet` version used
 A list of available versions can be found [here](https://hub.docker.com/r/shardlabs/cairo-cli/tags).
 ```javascript
 module.exports = {
-  cairo: {
+  starknet: {
     // The default in this version of the plugin
-    version: "0.7.0"
+    dockerizedVersion: "0.7.0"
   }
   ...
 };
 ```
 
 ### Existing virtual environment
-If you want to use an existing Python virtual environment, specify it by using `cairo["venv"]`.
+If you want to use an existing Python virtual environment, specify it by using `starknet["venv"]`.
 
 To use the currently activated environment (or if you have the starknet commands globally installed), set `venv` to `"active"`.
 ```typescript
 module.exports = {
-  cairo: {
+  starknet: {
     // venv: "active" <- for the active virtual environment
     // venv: "path/to/my-venv" <- for env created with e.g. `python -m venv path/to/my-venv`
     venv: "<VENV_PATH>"
@@ -286,7 +286,7 @@ module.exports = {
     // Has to be different from the value set in `paths.artifacts` (which is used by core Hardhat and has a default value of `artifacts`).
     starknetArtifacts: "also-my-own-starknet-path",
 
-   // Same purpose as the `--cairo-path` argument on for the `starknet-compile` command
+   // Same purpose as the `--cairo-path` argument of the `starknet-compile` command
    // Allows specifying the locations of imported files, if necessary.
     cairoPaths: ["cairo-path1", "cairo-path2"]
   }
@@ -295,21 +295,19 @@ module.exports = {
 ```
 
 ### Testing network
-To set the network used in your Mocha tests, use `mocha["starknetNetwork"]`. Not specifying one will default to using Alpha testnet.
+To set the network used in your Mocha tests, use `starknet["network"]`. Not specifying one will default to using Alpha testnet.
 
 A faster approach is to use [starknet-devnet](https://github.com/Shard-Labs/starknet-devnet), a Ganache-like local testnet.
 
 ```javascript
 module.exports = {
+  starknet: {
+    network: "myNetwork"
+  },
   networks: {
     myNetwork: {
       url: "http://localhost:5000"
     }
-  },
-  mocha: {
-    // Used for deployment in Mocha tests
-    // Defaults to "alpha" (for Alpha testnet), which is preconfigured even if you don't see it under `networks:`
-    starknetNetwork: "myNetwork"
   }
   ...
 };

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -28,8 +28,8 @@ export async function getContractFactoryUtil (hre: HardhatRuntimeEnvironment, co
     if (networkUrl) {
         gateway = networkUrl;
     } else {
-        testNetworkName = hre.config.mocha.starknetNetwork || DEFAULT_STARKNET_NETWORK;
-        const network = getNetwork(testNetworkName, hre, "mocha.starknetNetwork");
+        testNetworkName = hre.config.starknet.network || DEFAULT_STARKNET_NETWORK;
+        const network = getNetwork(testNetworkName, hre, "starknet.network");
         gateway = network.url;
     }
 
@@ -76,11 +76,10 @@ export function bigIntToShortStringUtil(convertableBigInt: BigInt) {
     return Buffer.from(convertableBigInt.toString(16), "hex").toString();
 }
 
-
 export function getWalletUtil(name: string, hre: HardhatRuntimeEnvironment) {
-    const wallet = hre.config.wallets[name];
+    const wallet = hre.config.starknet.wallets[name];
     if (!wallet) {
-        const available = Object.keys(hre.config.wallets).join(", ");
+        const available = Object.keys(hre.config.starknet.wallets).join(", ");
         const msg = `Invalid wallet name provided: ${name}.\nValid wallets: ${available}`;
         throw new HardhatPluginError(PLUGIN_NAME, msg);
     }

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -43,13 +43,13 @@ export async function getContractFactoryUtil (hre: HardhatRuntimeEnvironment, co
     });
 }
 
-export function stringToBigIntUtil(convertableString: string) {
+export function shortStringToBigIntUtil(convertableString: string) {
     if (!convertableString) {
         throw new HardhatPluginError(PLUGIN_NAME, "A non-empty string must be provided");
     }
 
     if (convertableString.length > SHORT_STRING_MAX_CHARACTERS) {
-        const msg = `Strings must have a max of ${SHORT_STRING_MAX_CHARACTERS} characters.`;
+        const msg = `Short strings must have a max of ${SHORT_STRING_MAX_CHARACTERS} characters.`;
         throw new HardhatPluginError(PLUGIN_NAME, msg);
     }
 
@@ -72,7 +72,7 @@ export function stringToBigIntUtil(convertableString: string) {
     return BigInt("0x" + charArray.join(""));
 }
 
-export function bigIntToStringUtil(convertableBigInt: BigInt) {
+export function bigIntToShortStringUtil(convertableBigInt: BigInt) {
     return Buffer.from(convertableBigInt.toString(16), "hex").toString();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { HardhatConfig, HardhatUserConfig } from "hardhat/types";
 import { getDefaultHttpNetworkConfig } from "./utils";
 import { DockerWrapper, VenvWrapper } from "./starknet-wrappers";
 import { starknetCompileAction, starknetDeployAction, starknetVoyagerAction, starknetInvokeAction, starknetCallAction, starknetDeployAccountAction } from "./task-actions";
-import { bigIntToStringUtil, getContractFactoryUtil, getWalletUtil, stringToBigIntUtil } from "./extend-utils";
+import { bigIntToShortStringUtil, getContractFactoryUtil, getWalletUtil, shortStringToBigIntUtil } from "./extend-utils";
 
 // add sources path
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
@@ -126,13 +126,13 @@ extendEnvironment(hre => {
             return contractFactory;
         },
 
-        stringToBigInt: convertableString => {
-            const convertedString = stringToBigIntUtil(convertableString);
+        shortStringToBigInt: convertableString => {
+            const convertedString = shortStringToBigIntUtil(convertableString);
             return convertedString;
         },
 
-        bigIntToString: convertableBigInt => {
-            const convertedBigInt = bigIntToStringUtil(convertableBigInt);
+        bigIntToShortString: convertableBigInt => {
+            const convertedBigInt = bigIntToShortStringUtil(convertableBigInt);
             return convertedBigInt;
         },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,11 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
 
 // add user-defined cairo settings
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
-    if (userConfig.cairo) {
-        config.cairo = JSON.parse(JSON.stringify(userConfig.cairo));
+    if (userConfig.starknet) {
+        config.starknet = JSON.parse(JSON.stringify(userConfig.starknet));
     }
-    if (!config.cairo) {
-        config.cairo = {};
+    if (!config.starknet) {
+        config.starknet = {};
     }
 });
 
@@ -70,16 +70,16 @@ extendConfig((config: HardhatConfig) => {
 
 // add venv wrapper or docker wrapper of starknet
 extendEnvironment(hre => {
-    const venvPath = hre.config.cairo.venv;
+    const venvPath = hre.config.starknet.venv;
     if (venvPath) {
-        if (hre.config.cairo.version) {
-            const msg = "Error in config file. Only one of (cairo.version, cairo.venv) can be specified.";
+        if (hre.config.starknet.dockerizedVersion) {
+            const msg = "Error in config file. Only one of (starknet.version, starknet.venv) can be specified.";
             throw new HardhatPluginError(PLUGIN_NAME, msg);
         }
         hre.starknetWrapper = new VenvWrapper(venvPath);
     } else {
         const repository = DOCKER_REPOSITORY;
-        const tag = hre.config.cairo.version || DEFAULT_DOCKER_IMAGE_TAG;
+        const tag = hre.config.starknet.dockerizedVersion || DEFAULT_DOCKER_IMAGE_TAG;
         hre.starknetWrapper = new DockerWrapper({ repository, tag });
     }
 });

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -7,21 +7,21 @@ import { PLUGIN_NAME } from "./constants";
 import { Choice } from "./types";
 import { adaptUrl } from "./utils";
 
-export interface CompileOptions {
+interface CompileWrapperOptions {
     file: string,
     output: string,
     abi: string,
     cairoPath: string,
 }
 
-export interface DeployOptions {
+interface DeployWrapperOptions {
     contract: string,
     gatewayUrl: string,
     inputs?: string[],
     salt?: string
 }
 
-export interface InvokeOrCallOptions {
+interface InvokeOrCallWrapperOptions {
     choice: Choice,
     address: string,
     abi: string,
@@ -37,13 +37,13 @@ export interface InvokeOrCallOptions {
     blockNumber?: string
 }
 
-export interface GetTxStatusOptions {
+interface GetTxStatusWrapperOptions {
     hash: string,
     gatewayUrl: string,
     feederGatewayUrl: string,
 }
 
-export interface DeployAccountOptions {
+interface DeployAccountWrapperOptions {
     wallet: string,
     accountName: string,
     accountDir: string,
@@ -53,7 +53,7 @@ export interface DeployAccountOptions {
 }
 
 export abstract class StarknetWrapper {
-    protected prepareCompileOptions(options: CompileOptions): string[] {
+    protected prepareCompileOptions(options: CompileWrapperOptions): string[] {
         return [
             options.file,
             "--abi", options.abi,
@@ -62,9 +62,9 @@ export abstract class StarknetWrapper {
         ];
     }
 
-    public abstract compile(options: CompileOptions): Promise<ProcessResult>;
+    public abstract compile(options: CompileWrapperOptions): Promise<ProcessResult>;
 
-    protected prepareDeployOptions(options: DeployOptions): string[] {
+    protected prepareDeployOptions(options: DeployWrapperOptions): string[] {
         const prepared = [
             "deploy",
             "--contract", options.contract,
@@ -82,9 +82,9 @@ export abstract class StarknetWrapper {
         return prepared;
     }
 
-    public abstract deploy(options: DeployOptions): Promise<ProcessResult>;
+    public abstract deploy(options: DeployWrapperOptions): Promise<ProcessResult>;
 
-    protected prepareInvokeOrCallOptions(options: InvokeOrCallOptions): string[] {
+    protected prepareInvokeOrCallOptions(options: InvokeOrCallWrapperOptions): string[] {
         const prepared = [
             options.choice,
             "--abi", options.abi,
@@ -123,9 +123,9 @@ export abstract class StarknetWrapper {
         return prepared;
     }
 
-    public abstract invokeOrCall(options: InvokeOrCallOptions): Promise<ProcessResult>;
+    public abstract invokeOrCall(options: InvokeOrCallWrapperOptions): Promise<ProcessResult>;
 
-    protected prepareGetTxStatusOptions(options: GetTxStatusOptions): string[] {
+    protected prepareGetTxStatusOptions(options: GetTxStatusWrapperOptions): string[] {
         return [
             "tx_status",
             "--hash", options.hash,
@@ -134,9 +134,9 @@ export abstract class StarknetWrapper {
         ];
     }
 
-    public abstract getTxStatus(options: GetTxStatusOptions): Promise<ProcessResult>;
+    public abstract getTxStatus(options: GetTxStatusWrapperOptions): Promise<ProcessResult>;
 
-    protected getPythonDeployAccountScript(options: DeployAccountOptions): string {
+    protected getPythonDeployAccountScript(options: DeployAccountWrapperOptions): string {
 
         const wallet = options.wallet? "'" + options.wallet + "'" : "None";
         const accountName = options.accountName? "'" + options.accountName + "'" : "'__default__'";
@@ -166,7 +166,7 @@ export abstract class StarknetWrapper {
         return script;
 
     }
-    public abstract deployAccount(options: DeployAccountOptions): Promise<ProcessResult>;
+    public abstract deployAccount(options: DeployAccountWrapperOptions): Promise<ProcessResult>;
 }
 
 function getFullImageName(image: Image): string {
@@ -220,7 +220,7 @@ export class DockerWrapper extends StarknetWrapper {
         return this.docker;
     }
 
-    public async compile(options: CompileOptions): Promise<ProcessResult> {
+    public async compile(options: CompileWrapperOptions): Promise<ProcessResult> {
         const binds: String2String = {
             [options.file]: options.file,
             [options.abi]: options.abi,
@@ -241,7 +241,7 @@ export class DockerWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async deploy(options: DeployOptions): Promise<ProcessResult> {
+    public async deploy(options: DeployWrapperOptions): Promise<ProcessResult> {
         const binds: String2String = {
             [options.contract]: options.contract
         };
@@ -259,7 +259,7 @@ export class DockerWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async invokeOrCall(options: InvokeOrCallOptions): Promise<ProcessResult> {
+    public async invokeOrCall(options: InvokeOrCallWrapperOptions): Promise<ProcessResult> {
         const binds: String2String = {
             [options.abi]: options.abi
         };
@@ -282,7 +282,7 @@ export class DockerWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async getTxStatus(options: GetTxStatusOptions): Promise<ProcessResult> {
+    public async getTxStatus(options: GetTxStatusWrapperOptions): Promise<ProcessResult> {
         const binds: String2String = {};
 
         const dockerOptions = {
@@ -297,7 +297,7 @@ export class DockerWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async deployAccount(options: DeployAccountOptions): Promise<ProcessResult> {
+    public async deployAccount(options: DeployAccountWrapperOptions): Promise<ProcessResult> {
         const binds: String2String = {
             [options.accountDir]: options.accountDir
         };
@@ -363,31 +363,31 @@ export class VenvWrapper extends StarknetWrapper {
         };
     }
 
-    public async compile(options: CompileOptions): Promise<ProcessResult> {
+    public async compile(options: CompileWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareCompileOptions(options);
         const executed = await this.execute(this.starknetCompilePath, preparedOptions);
         return executed;
     }
 
-    public async deploy(options: DeployOptions): Promise<ProcessResult> {
+    public async deploy(options: DeployWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareDeployOptions(options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }
 
-    public async invokeOrCall(options: InvokeOrCallOptions): Promise<ProcessResult> {
+    public async invokeOrCall(options: InvokeOrCallWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareInvokeOrCallOptions(options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }
 
-    public async getTxStatus(options: GetTxStatusOptions): Promise<ProcessResult> {
+    public async getTxStatus(options: GetTxStatusWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareGetTxStatusOptions(options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }
 
-    public async deployAccount(options: DeployAccountOptions): Promise<ProcessResult> {
+    public async deployAccount(options: DeployAccountWrapperOptions): Promise<ProcessResult> {
         const deployAccountScript = this.getPythonDeployAccountScript(options);
         const executed = await this.execute("python", ["-c", deployAccountScript]);
         return executed;

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -53,7 +53,6 @@ function isStarknetCompilationArtifact(filePath: string) {
     return !!parsed.entry_points_by_type;
 }
 
-
 /**
  * First deletes the file if it already exists. Then creates an empty file at the provided path.
  * Unlinking/deleting is necessary if user switched from docker to venv.
@@ -69,8 +68,6 @@ function initializeFile(filePath: string) {
 function getFileName(filePath: string) {
     return path.basename(filePath, path.extname(filePath));
 }
-
-
 
 /**
  * Extracts gatewayUrl from args or process.env.STARKNET_NETWORK. Sets hre.starknet.network if provided.

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -79,14 +79,14 @@ declare module "hardhat/types/runtime" {
              * @param input the input short string
              * @returns the numeric equivalent of the input short string, wrapped in a `BigInt`
              */
-            stringToBigInt: (convertableString: string) => BigInt;
+            shortStringToBigInt: (convertableString: string) => BigInt;
 
             /**
-             * Converts a BigInt to a string. The opposite of {@link stringToBigInt}.
+             * Converts a BigInt to a string. The opposite of {@link shortStringToBigInt}.
              * @param input the input BigInt
              * @returns a string which is the result of converting a BigInt's hex value to its ASCII equivalent
              */
-            bigIntToString: (convertableBigInt: BigInt) => string;
+            bigIntToShortString: (convertableBigInt: BigInt) => string;
 
             /**
              * The selected starknet-network, present if the called task relies on `--starknet-network` or `mocha.starknetNetwork`.

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -3,9 +3,11 @@ import "hardhat/types/runtime";
 import { StarknetContract, StarknetContractFactory, StringMap } from "./types";
 import { StarknetWrapper } from "./starknet-wrappers";
 
-type CairoConfig = {
-    version?: string;
+type StarknetConfig = {
+    dockerizedVersion?: string;
     venv?: string;
+    wallets?: WalletUserConfig;
+    network?: string;
 }
 
 type WalletUserConfig = {
@@ -32,13 +34,11 @@ declare module "hardhat/types/config" {
     }
 
     export interface HardhatConfig {
-        cairo: CairoConfig;
-        wallets: WalletUserConfig;
+        starknet: StarknetConfig;
     }
 
     export interface HardhatUserConfig {
-        cairo?: CairoConfig;
-        wallets?: WalletUserConfig;
+        starknet?: StarknetConfig;
     }
 
     export interface NetworksConfig {
@@ -89,7 +89,7 @@ declare module "hardhat/types/runtime" {
             bigIntToShortString: (convertableBigInt: BigInt) => string;
 
             /**
-             * The selected starknet-network, present if the called task relies on `--starknet-network` or `mocha.starknetNetwork`.
+             * The selected starknet-network, present if the called task relies on `--starknet-network` or `starknet["network"]` in the config object.
              */
             network?: string;
 
@@ -105,10 +105,4 @@ declare module "hardhat/types/runtime" {
     type StarknetContractFactory = StarknetContractFactoryType;
     type StringMap = StringMapType;
     type Wallet = WalletConfig;
-}
-
-declare module "mocha" {
-    export interface MochaOptions {
-        starknetNetwork?: string;
-    }
 }

--- a/test/configuration-tests/with-artifacts-path/hardhat.config.ts
+++ b/test/configuration-tests/with-artifacts-path/hardhat.config.ts
@@ -1,6 +1,9 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     paths: {
         starknetArtifacts: "my-starknet-artifacts"
     },
@@ -8,8 +11,5 @@ module.exports = {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/configuration-tests/with-cairo-version/hardhat.config.ts
+++ b/test/configuration-tests/with-cairo-version/hardhat.config.ts
@@ -1,15 +1,13 @@
 import "../dist/index.js";
 
 module.exports = {
-    cairo: {
-        version: "0.7.0"
+    starknet: {
+        dockerizedVersion: "0.7.0",
+        network: process.env.NETWORK
     },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/configuration-tests/with-cli-paths/hardhat.config.ts
+++ b/test/configuration-tests/with-cli-paths/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/configuration-tests/with-deploy-inputs/hardhat.config.ts
+++ b/test/configuration-tests/with-deploy-inputs/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/configuration-tests/with-deploy-path/hardhat.config.ts
+++ b/test/configuration-tests/with-deploy-path/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/configuration-tests/with-networks/hardhat.config.ts
+++ b/test/configuration-tests/with-networks/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/configuration-tests/with-networks/invalid-mocha-network.txt
+++ b/test/configuration-tests/with-networks/invalid-mocha-network.txt
@@ -2,5 +2,5 @@
 
   1) ContractFactory
        should be created:
-     HardhatPluginError: Invalid network provided in mocha.starknetNetwork: foo.
+     HardhatPluginError: Invalid network provided in starknet.network: foo.
 Valid hardhat networks: hardhat, localhost, devnet, alpha, alphaMainnet

--- a/test/configuration-tests/with-sources-path/hardhat.config.ts
+++ b/test/configuration-tests/with-sources-path/hardhat.config.ts
@@ -1,6 +1,9 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     paths: {
         starknetSources: "my-starknet-sources"
     },
@@ -8,8 +11,5 @@ module.exports = {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/configuration-tests/with-wait/hardhat.config.ts
+++ b/test/configuration-tests/with-wait/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/general-tests/function-argument-number/hardhat.config.ts
+++ b/test/general-tests/function-argument-number/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/general-tests/open-zeppelin-cairo-contracts/hardhat.config.ts
+++ b/test/general-tests/open-zeppelin-cairo-contracts/hardhat.config.ts
@@ -1,7 +1,7 @@
 import "../dist/index.js";
 
 module.exports = {
-    cairo: {
-        version: "0.7.0"
+    starknet: {
+        dockerizedVersion: "0.7.0"
     }
 };

--- a/test/general-tests/plain/hardhat.config.ts
+++ b/test/general-tests/plain/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/general-tests/short-string-test/short-string-test.ts
+++ b/test/general-tests/short-string-test/short-string-test.ts
@@ -36,7 +36,7 @@ describe("Starknet", function () {
             starknet.shortStringToBigInt(largeString);
             expect.fail("Should have failed on converting a string with more than 31 characters.");
         } catch (err: any) {
-            expect(err.message).to.deep.equal("Strings must have a max of 31 characters.");
+            expect(err.message).to.deep.equal("Short strings must have a max of 31 characters.");
         }
     });
 
@@ -46,7 +46,7 @@ describe("Starknet", function () {
             starknet.shortStringToBigInt(invalidLengthString);
             expect.fail("Should have failed on converting a string with more than 31 characters.");
         } catch (err: any) {
-            expect(err.message).to.deep.equal("Strings must have a max of 31 characters.");
+            expect(err.message).to.deep.equal("Short strings must have a max of 31 characters.");
         }
     });
 

--- a/test/general-tests/short-string-test/short-string-test.ts
+++ b/test/general-tests/short-string-test/short-string-test.ts
@@ -16,24 +16,24 @@ describe("Starknet", function () {
     const multipleInvalidCharactersString = "invaliđ čarđ";
 
     it("should convert a valid string to a BigInt", async function() {
-        const convertedInput = starknet.stringToBigInt(inputString);
+        const convertedInput = starknet.shortStringToBigInt(inputString);
         expect(convertedInput).to.deep.equal(convertedString);
     });
 
     it("should convert a string with exactly 31 characters to a BigInt", async function() {
-        const convertedInput = starknet.stringToBigInt(exactString);
+        const convertedInput = starknet.shortStringToBigInt(exactString);
         expect(convertedInput).to.deep.equal(convertedExactString);
     });
 
     it("should convert a BigInt to a string", async function() {
-        const convertedOutput = starknet.bigIntToString(convertedString);
+        const convertedOutput = starknet.bigIntToShortString(convertedString);
         expect(convertedOutput).to.deep.equal(inputString);
     });
 
     it("should fail when a string has exactly 32 characters", async function() {
 
         try {
-            starknet.stringToBigInt(largeString);
+            starknet.shortStringToBigInt(largeString);
             expect.fail("Should have failed on converting a string with more than 31 characters.");
         } catch (err: any) {
             expect(err.message).to.deep.equal("Strings must have a max of 31 characters.");
@@ -43,7 +43,7 @@ describe("Starknet", function () {
     it("should fail when a string has over 31 characters", async function() {
 
         try {
-            starknet.stringToBigInt(invalidLengthString);
+            starknet.shortStringToBigInt(invalidLengthString);
             expect.fail("Should have failed on converting a string with more than 31 characters.");
         } catch (err: any) {
             expect(err.message).to.deep.equal("Strings must have a max of 31 characters.");
@@ -53,7 +53,7 @@ describe("Starknet", function () {
     it("should fail when a string has a non-standard-ASCII character", async function() {
 
         try {
-            starknet.stringToBigInt(invalidCharacterString);
+            starknet.shortStringToBigInt(invalidCharacterString);
             expect.fail("Should have failed on converting a string with an invalid character.");
         } catch (err: any) {
             expect(err.message).to.deep.equal("Non-standard-ASCII character: ÿ");
@@ -63,7 +63,7 @@ describe("Starknet", function () {
     it("should fail when a string has multiple non-standard-ASCII characters", async function() {
 
         try {
-            starknet.stringToBigInt(multipleInvalidCharactersString);
+            starknet.shortStringToBigInt(multipleInvalidCharactersString);
             expect.fail("Should have failed on converting a string with invalid characters.");
         } catch (err: any) {
             expect(err.message).to.deep.equal("Non-standard-ASCII characters: đ, č");

--- a/test/general-tests/starknet-call/hardhat.config.ts
+++ b/test/general-tests/starknet-call/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/general-tests/starknet-invoke/hardhat.config.ts
+++ b/test/general-tests/starknet-invoke/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/general-tests/starknet-verify/hardhat.config.ts
+++ b/test/general-tests/starknet-verify/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/general-tests/transaction-signing/hardhat.config.ts
+++ b/test/general-tests/transaction-signing/hardhat.config.ts
@@ -1,12 +1,12 @@
 import "../dist/index.js";
 
 module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/general-tests/wallet-test/hardhat.config.ts
+++ b/test/general-tests/wallet-test/hardhat.config.ts
@@ -6,14 +6,14 @@ module.exports = {
             url: "http://localhost:5000"
         }
     },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
-    },
-    wallets: {
-        OpenZeppelin: {
-            accountName: "OpenZeppelin",
-            modulePath: "starkware.starknet.wallets.open_zeppelin.OpenZeppelinAccount",
-            accountPath: "~/.starknet_accounts"
+    starknet: {
+        network: process.env.NETWORK,
+        wallets: {
+            OpenZeppelin: {
+                accountName: "OpenZeppelin",
+                modulePath: "starkware.starknet.wallets.open_zeppelin.OpenZeppelinAccount",
+                accountPath: "~/.starknet_accounts"
+            }
         }
     }
 };

--- a/test/venv-tests/with-venv-active/hardhat.config.ts
+++ b/test/venv-tests/with-venv-active/hardhat.config.ts
@@ -1,15 +1,13 @@
 import "../dist/index.js";
 
 module.exports = {
-    cairo: {
-        venv: "active"
+    starknet: {
+        venv: "active",
+        network: process.env.NETWORK
     },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };

--- a/test/venv-tests/with-venv/hardhat.config.ts
+++ b/test/venv-tests/with-venv/hardhat.config.ts
@@ -1,15 +1,13 @@
 import "../dist/index.js";
 
 module.exports = {
-    cairo: {
-        venv: "../my-venv"
+    starknet: {
+        venv: "../my-venv",
+        network: process.env.NETWORK
     },
     networks: {
         devnet: {
             url: "http://localhost:5000"
         }
-    },
-    mocha: {
-        starknetNetwork: process.env.NETWORK
     }
 };


### PR DESCRIPTION
## Usage
- Rename string to shortString:
  - `stringToBigInt` -> `shortStringToBigInt`
  - `bigIntToString` -> `bigIntToShortString`
- Restructure `hardhat.config`:
  - Use `starknet` key.
  - Stop using `cairo` key:
    - Rename `version` to `dockerizedVersion`
  - Move `wallets` to `starknet`.
  - Move `starknetNetwork` from `mocha` to `starknet`.
- Use `options` object in `StarknetContract` methods instead of using optional function arguments.
- Add Docker issue fix to Readme.

## Dev
- No dev-specific changes to list.