### PR TITLE
Fix poetry to version 1.1.12

### DIFF
--- a/scripts/install-devnet.sh
+++ b/scripts/install-devnet.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
+
 set -e
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - --version 1.1.12
 
 git clone -b master --single-branch git@github.com:Shard-Labs/starknet-devnet.git
 
-source $HOME/.poetry/env
+source "$HOME/.poetry/env"
 
 cd starknet-devnet 
-
 poetry build
-
 pip3 install dist/starknet_devnet-*-py3-none-any.whl
-
 cd ..


### PR DESCRIPTION
## Usage
- No changes to how the plugin is used.

## Dev
- Fix poetry version to 1.1.12 because using the latest (1.1.13 currently) is not working. @dribeiro-ShardLabs does this have to do anything with caching? Perhaps if venv was cached?
- Also changed the formatting of `install-devnet.sh`.