### PR TITLE
Automatic account artifacts fetching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ workflows:
           matrix:
             parameters:
               platform: [linux-node14, macos-node14]
-              test-name: [test-general-tests, test-configuration-tests, test-venv-tests]
+              test-name: [test-general-tests]
             exclude:
               - platform: macos-node14
                 test-name: test-general-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ workflows:
           matrix:
             parameters:
               platform: [linux-node14, macos-node14]
-              test-name: [test-general-tests]
+              test-name: [test-general-tests, test-configuration-tests, test-venv-tests]
             exclude:
               - platform: macos-node14
                 test-name: test-general-tests

--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -1,0 +1,124 @@
+import { Numeric } from "./types";
+import { hash } from "starknet";
+import { BigNumberish, toBN } from "starknet/utils/number";
+import * as ellipticCurve from "starknet/utils/ellipticCurve";
+import { ec } from "elliptic";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import * as fs from "fs";
+import path from "path";
+import {
+    ABI_SUFFIX,
+    ACCOUNT_ARTIFACTS_VERSION,
+    ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH,
+    GITHUB_ACCOUNT_SHA_URL
+} from "./constants";
+import axios from "axios";
+
+/*
+ * Helper cryptography functions for Key generation and message signing
+ */
+
+export function generateRandomStarkPrivateKey(length = 63) {
+    const characters = "0123456789ABCDEF";
+    let result = "";
+    for (let i = 0; i < length; ++i) {
+        result += characters.charAt(Math.floor(Math.random() * characters.length));
+    }
+    return toBN(result, "hex");
+}
+
+/**
+ * Returns a signature which is the result of signing a message
+ *
+ * @param keyPair
+ * @param accountAddress
+ * @param nonce
+ * @param functionSelector
+ * @param toAddress
+ * @param calldata
+ * @returns the signature
+ */
+export function sign(
+    keyPair: ec.KeyPair,
+    accountAddress: string,
+    nonce: BigNumberish,
+    functionSelector: string,
+    toAddress: string,
+    calldata: BigNumberish[]
+): Numeric[] {
+    const msgHash = hash.computeHashOnElements([
+        toBN(accountAddress.substring(2), "hex"),
+        toBN(toAddress.substring(2), "hex"),
+        functionSelector,
+        toBN(hash.computeHashOnElements(calldata).substring(2), "hex"),
+        nonce
+    ]);
+
+    const signedMessage = ellipticCurve.sign(keyPair, BigInt(msgHash).toString(16));
+    const signature = [
+        BigInt("0x" + signedMessage[0].toString(16)),
+        BigInt("0x" + signedMessage[1].toString(16))
+    ];
+    return signature;
+}
+
+export async function handleAccountContractArtifacts(
+    accountType: string,
+    artifactsName: string,
+    hre: HardhatRuntimeEnvironment
+) {
+    // Name of the artifacts' parent folder
+    const targetPath = artifactsName + ".cairo";
+
+    // Full path to where the artifacts will be saved
+    const artifactsTargetPath = path.join(
+        hre.config.paths.starknetArtifacts,
+        ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH,
+        ACCOUNT_ARTIFACTS_VERSION,
+        targetPath
+    );
+
+    if (!fs.existsSync(artifactsTargetPath)) {
+        const baseArtifactsPath = path.join(
+            hre.config.paths.starknetArtifacts,
+            ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH
+        );
+        if (fs.existsSync(baseArtifactsPath)) {
+            fs.rmSync(baseArtifactsPath, { recursive: true, force: true });
+        }
+
+        const artifacts = {
+            json: artifactsName + ".json",
+            abi: artifactsName + ABI_SUFFIX
+        };
+
+        fs.mkdirSync(artifactsTargetPath, { recursive: true });
+
+        const githubTree = GITHUB_ACCOUNT_SHA_URL.concat("/", accountType, "/", targetPath);
+
+        let jsonBlobUrl, abiBlobUrl;
+
+        // Get the url to the file blobs through the github api tree, because if the files are too large, the regular method of retrieving will not work
+        await axios({
+            method: "get",
+            url: githubTree
+        }).then(async (response) => {
+            jsonBlobUrl = response.data.tree.find(
+                (artifact: any) => artifact.path === artifacts.json
+            ).url;
+            abiBlobUrl = response.data.tree.find(
+                (artifact: any) => artifact.path === artifacts.abi
+            ).url;
+        });
+
+        const jsonBase64 = (await axios.get(jsonBlobUrl)).data.content;
+        const abiBase64 = (await axios.get(abiBlobUrl)).data.content;
+
+        fs.writeFileSync(path.join(artifactsTargetPath, artifacts.json), jsonBase64, {
+            encoding: "base64"
+        });
+        fs.writeFileSync(path.join(artifactsTargetPath, artifacts.abi), abiBase64, {
+            encoding: "base64"
+        });
+    }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,10 @@ export const DEFAULT_STARKNET_ACCOUNT_PATH = "~/.starknet_accounts";
 export const DOCKER_REPOSITORY = "shardlabs/cairo-cli";
 export const DEFAULT_DOCKER_IMAGE_TAG = "0.7.1";
 
+export const ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH = "account-contract-artifacts";
+export const ACCOUNT_ARTIFACTS_VERSION = "0.1.0";
+export const GITHUB_ACCOUNT_SHA_URL = `https://api.github.com/repos/Shard-Labs/starknet-hardhat-example/git/trees/plugin:account-contract-artifacts/${ACCOUNT_ARTIFACTS_VERSION}`;
+
 export const ALPHA_TESTNET = "alpha-goerli";
 export const ALPHA_TESTNET_INTERNALLY = "alpha";
 export const ALPHA_MAINNET = "alpha-mainnet";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ export const DEFAULT_DOCKER_IMAGE_TAG = "0.7.1";
 
 export const ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH = "account-contract-artifacts";
 export const ACCOUNT_ARTIFACTS_VERSION = "0.1.0";
-export const GITHUB_ACCOUNT_SHA_URL = `https://api.github.com/repos/Shard-Labs/starknet-hardhat-example/git/trees/plugin:account-contract-artifacts/${ACCOUNT_ARTIFACTS_VERSION}`;
+export const GITHUB_ACCOUNT_ARTIFACTS_URL = `https://raw.githubusercontent.com/Shard-Labs/starknet-hardhat-example/plugin/account-contract-artifacts/${ACCOUNT_ARTIFACTS_VERSION}`;
 
 export const ALPHA_TESTNET = "alpha-goerli";
 export const ALPHA_TESTNET_INTERNALLY = "alpha";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ export const DEFAULT_DOCKER_IMAGE_TAG = "0.7.1";
 
 export const ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH = "account-contract-artifacts";
 export const ACCOUNT_ARTIFACTS_VERSION = "0.1.0";
-export const GITHUB_ACCOUNT_ARTIFACTS_URL = `https://raw.githubusercontent.com/Shard-Labs/starknet-hardhat-example/plugin/account-contract-artifacts/${ACCOUNT_ARTIFACTS_VERSION}`;
+export const GITHUB_ACCOUNT_ARTIFACTS_URL = `https://raw.githubusercontent.com/Shard-Labs/starknet-hardhat-example/plugin/${ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH}/${ACCOUNT_ARTIFACTS_VERSION}/`;
 
 export const ALPHA_TESTNET = "alpha-goerli";
 export const ALPHA_TESTNET_INTERNALLY = "alpha";

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -24,6 +24,7 @@ export async function getContractFactoryUtil(
         `${contractPath}.cairo`,
         `${path.basename(contractPath)}.json`
     );
+
     const metadataPath = await findPath(artifactsPath, metadataSearchTarget);
     if (!metadataPath) {
         throw new HardhatPluginError(PLUGIN_NAME, `Could not find metadata for ${contractPath}`);
@@ -95,14 +96,13 @@ export function getWalletUtil(name: string, hre: HardhatRuntimeEnvironment) {
 }
 
 export async function deployAccountFromABIUtil(
-    accountContract: string,
     accountType: AccountImplementationType,
     hre: HardhatRuntimeEnvironment
 ): Promise<Account> {
     let account: Account;
     switch (accountType) {
         case "OpenZeppelin":
-            account = await OpenZeppelinAccount.deployFromABI(accountContract, hre);
+            account = await OpenZeppelinAccount.deployFromABI(hre);
             break;
         default:
             throw new HardhatPluginError(PLUGIN_NAME, "Invalid account type requested.");
@@ -112,7 +112,6 @@ export async function deployAccountFromABIUtil(
 }
 
 export async function getAccountFromAddressUtil(
-    accountContract: string,
     address: string,
     privateKey: string,
     accountType: AccountImplementationType,
@@ -122,7 +121,6 @@ export async function getAccountFromAddressUtil(
     switch (accountType) {
         case "OpenZeppelin":
             account = await OpenZeppelinAccount.getAccountFromAddress(
-                accountContract,
                 address,
                 privateKey,
                 hre

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,14 +181,13 @@ extendEnvironment((hre) => {
 
         devnet: lazyObject(() => new DevnetUtils(hre)),
 
-        deployAccountFromABI: async (accountContract, accountType) => {
-            const account = await deployAccountFromABIUtil(accountContract, accountType, hre);
+        deployAccountFromABI: async (accountType) => {
+            const account = await deployAccountFromABIUtil(accountType, hre);
             return account;
         },
 
-        getAccountFromAddress: async (accountContract, address, privateKey, accountType) => {
+        getAccountFromAddress: async (address, privateKey, accountType) => {
             const account = await getAccountFromAddressUtil(
-                accountContract,
                 address,
                 privateKey,
                 accountType,

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -142,7 +142,6 @@ declare module "hardhat/types/runtime" {
              * @returns an Account object
              */
             deployAccountFromABI: (
-                accountContract: string,
                 accountType: AccountImplementationType
             ) => Promise<Account>;
 
@@ -155,7 +154,6 @@ declare module "hardhat/types/runtime" {
              * @returns an Account object
              */
             getAccountFromAddress: (
-                accountContract: string,
                 address: string,
                 privateKey: string,
                 accountType: AccountImplementationType

--- a/test/general-tests/account-test/check.sh
+++ b/test/general-tests/account-test/check.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+DUMMY_DIR=starknet-artifacts/account-contract-artifacts/0.0.0/Account.cairo
+
+mkdir "$DUMMY_DIR"
+
 npx hardhat starknet-compile contracts/contract.cairo
 
 npx hardhat test --no-compile test/account-test.ts
+
+echo "Testing removal of dummy directory"
+if [ -d "$DUMMY_DIR" ]; then
+exit 1
+fi
+echo "Success"

--- a/test/general-tests/account-test/check.sh
+++ b/test/general-tests/account-test/check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-npx hardhat starknet-compile contracts/contract.cairo contracts/Account.cairo
+npx hardhat starknet-compile contracts/contract.cairo
 
 npx hardhat test --no-compile test/account-test.ts

--- a/test/general-tests/account-test/check.sh
+++ b/test/general-tests/account-test/check.sh
@@ -3,7 +3,7 @@ set -e
 
 DUMMY_DIR=starknet-artifacts/account-contract-artifacts/0.0.0/Account.cairo
 
-mkdir "$DUMMY_DIR"
+mkdir -p "$DUMMY_DIR"
 
 npx hardhat starknet-compile contracts/contract.cairo
 
@@ -11,6 +11,7 @@ npx hardhat test --no-compile test/account-test.ts
 
 echo "Testing removal of dummy directory"
 if [ -d "$DUMMY_DIR" ]; then
-exit 1
+    # If path exists, exit with an error because it should have been deleted while fetching the correct artifacts
+    exit 1
 fi
 echo "Success"


### PR DESCRIPTION
Fetching the artifacts for the account contract automatically, so the contract name parameter is removed from the functions `deployFromABI` and `getAccountFromAddress`