### PR TITLE
Fix empty constructor

### DIFF
--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -33,7 +33,7 @@ function isNumeric(value: { toString: () => string }) {
  * ```
  * @param functionName the name of the function whose input is adapted
  * @param input the input object containing function arguments under their names
- * @param inputSpecs extracted from inputs
+ * @param inputSpecs ABI specifications extracted from function.inputs
  * @param abi the ABI artifact of compilation, parsed into an object
  * @returns array containing stringified function arguments in the correct order
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,34 +311,12 @@ export class StarknetContractFactory {
     }
 
     private handleConstructorArguments(constructorArguments: StringMap): string[] {
-        if (this.constructorAbi) {
-            if (!constructorArguments || Object.keys(constructorArguments).length === 0) {
-                throw new HardhatPluginError(
-                    PLUGIN_NAME,
-                    "Constructor arguments required but not provided."
-                );
-            }
-            const argumentArray = adaptInputUtil(
-                this.constructorAbi.name,
-                constructorArguments,
-                this.constructorAbi.inputs,
-                this.abi
-            );
-
-            return argumentArray;
-        }
-
-        if (constructorArguments && Object.keys(constructorArguments).length) {
-            if (!this.constructorAbi) {
-                throw new HardhatPluginError(
-                    PLUGIN_NAME,
-                    "Constructor arguments provided but not required."
-                );
-            }
-            // other case already handled
-        }
-
-        return [];
+        return adaptInputUtil(
+            this.constructorAbi.name,
+            constructorArguments,
+            this.constructorAbi.inputs,
+            this.abi
+        );
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,6 +311,14 @@ export class StarknetContractFactory {
     }
 
     private handleConstructorArguments(constructorArguments: StringMap): string[] {
+        if (!this.constructorAbi) {
+            const argsProvided = Object.keys(constructorArguments || {}).length;
+            if (argsProvided) {
+                const msg = `No constructor arguments required but ${argsProvided} provided`;
+                throw new HardhatPluginError(PLUGIN_NAME, msg);
+            }
+            return [];
+        }
         return adaptInputUtil(
             this.constructorAbi.name,
             constructorArguments,

--- a/test/general-tests/constructor-test/check.sh
+++ b/test/general-tests/constructor-test/check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+npx hardhat starknet-compile contracts/contract.cairo contracts/simple_storage.cairo contracts/empty_constructor.cairo
+npx hardhat test --no-compile test/constructor.test.ts

--- a/test/general-tests/constructor-test/hardhat.config.ts
+++ b/test/general-tests/constructor-test/hardhat.config.ts
@@ -1,0 +1,12 @@
+import "../dist/index.js";
+
+module.exports = {
+    starknet: {
+        network: "devnet"
+    },
+    networks: {
+        devnet: {
+            url: "http://localhost:5000"
+        }
+    }
+};

--- a/test/general-tests/constructor-test/network.json
+++ b/test/general-tests/constructor-test/network.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../network.schema",
+    "devnet": true
+}


### PR DESCRIPTION
## Usage changes
- Support contracts with empty constructors (constructors with no arguments).

## Dev specific changes
- `handleConstructorArguments` is simplified
- Constructor behavior is tested in a separate test (only on devnet).