### PR TITLE
Rename deployAccountFromABI to deployAccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ More detailed documentation can be found [here](#account).
     const contractFactory = await starknet.getContractFactory("MyContract");
     const contract = await contractFactory.deploy()
 
-    const account = await starknet.deployAccountFromABI("Account", "OpenZeppelin");
+    const account = await starknet.deployAccount("OpenZeppelin");
     // or
-    const account = await starknet.getAccountFromAddress("Account", accountAddress, process.env.PRIVATE_KEY, "OpenZeppelin");
+    const account = await starknet.getAccountFromAddress(accountAddress, process.env.PRIVATE_KEY, "OpenZeppelin");
     console.log("Account:", account.starknetContract.address, account.privateKey, account.publicKey);
 
     const { res: currBalance } = await account.call(contract, "get_balance");
@@ -393,39 +393,35 @@ Currently only the OpenZeppelin Account implementation is supported, and you are
 
 You can choose to deploy a new Account, or use an existing one.
 
-To deploy a new Account, use the `starknet` object's `deployAccountFromABI` method:
-```javascript
-function deployAccountFromABI: (
-                accountContract: string,
-                accountType: AccountImplementationType
-            )
+To deploy a new Account, use the `starknet` object's `deployAccount` method:
+```typescript
+function deployAccount (
+    accountType: AccountImplementationType
+)
 ```
-  - `accountContract` is the **name** or the **path** of the source of the Account contract, just like in `getContractFactory`.
-  - `accountType` is the implementation of the Account that you want to use. Currently only "OpenZeppelin" is supported.
-```javascript
-account = await starknet.deployAccountFromABI("Account", "OpenZeppelin");
+  - `accountType` is the implementation of the Account that you want to use. Currently only `"OpenZeppelin"` is supported.
+```typescript
+account = await starknet.deployAccount("OpenZeppelin");
 ```
 
 To retrieve an already deployed Account, use the `starknet` object's `getAccountFromAddress` method:
-```javascript
-function getAccountFromAddress: (
-                accountContract: string,
-                address: string,
-                privateKey: string,
-                accountType: AccountImplementationType
-            )
+```typescript
+function getAccountFromAddress (
+    address: string,
+    privateKey: string,
+    accountType: AccountImplementationType
+)
 ```
-  - `accountContract` is the is the **name** or the **path** of the source of the Account contract, just like in `getContractFactory`.
   - `address` is the address where the account you want to use is deployed.
   - `privateKey` is the account's private key.
-  - `accountType` is the implementation of the Account that you want to use. Currently only "OpenZeppelin" is supported.
+  - `accountType` is the implementation of the Account that you want to use. Currently only `"OpenZeppelin"` is supported.
 
-```javascript
-const account = await starknet.getAccountFromAddress("Account", accountAddress, process.env.PRIVATE_KEY, "OpenZeppelin");
+```typescript
+const account = await starknet.getAccountFromAddress(accountAddress, process.env.PRIVATE_KEY, "OpenZeppelin");
 ```
 
 You can then use the Account object to call and invoke your contracts using the `invoke` and `call` methods, that take as arguments the target contract, function name, and arguments:
-```javascript
+```typescript
 const { res: currBalance } = await account.call(contract, "get_balance");
 await account.invoke(contract, "increase_balance", { amount });
 ```

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -5,20 +5,20 @@ import { Devnet, HardhatRuntimeEnvironment } from "hardhat/types";
 import { PLUGIN_NAME } from "./constants";
 
 interface L1Message {
-    address: string,
+    address: string;
     args: {
-        from_address: string,
-        nonce: number,
-        payload: Array<number>,
-        selector: string,
-        to_address: string
-    },
-    blockHash: string,
-    blockNumber: number,
-    event: string,
-    logIndex: number,
-    transactionHash: string,
-    transactionIndex: number
+        from_address: string;
+        nonce: number;
+        payload: Array<number>;
+        selector: string;
+        to_address: string;
+    };
+    blockHash: string;
+    blockNumber: number;
+    event: string;
+    logIndex: number;
+    transactionHash: string;
+    transactionIndex: number;
 }
 
 interface L2Message {
@@ -32,7 +32,7 @@ export interface FlushResponse {
     consumed_messages: {
         from_l1: Array<L1Message>;
         from_l2: Array<L2Message>;
-    }
+    };
 }
 
 export interface LoadL1MessagingContractResponse {

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -88,7 +88,7 @@ export function getWalletUtil(name: string, hre: HardhatRuntimeEnvironment) {
     return wallet;
 }
 
-export async function deployAccountFromABIUtil(
+export async function deployAccountUtil(
     accountType: AccountImplementationType,
     hre: HardhatRuntimeEnvironment
 ): Promise<Account> {
@@ -113,11 +113,7 @@ export async function getAccountFromAddressUtil(
     let account: Account;
     switch (accountType) {
         case "OpenZeppelin":
-            account = await OpenZeppelinAccount.getAccountFromAddress(
-                address,
-                privateKey,
-                hre
-            );
+            account = await OpenZeppelinAccount.getAccountFromAddress(address, privateKey, hre);
             break;
         default:
             throw new HardhatPluginError(PLUGIN_NAME, "Invalid account type requested.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,12 +202,7 @@ extendEnvironment((hre) => {
         },
 
         getAccountFromAddress: async (address, privateKey, accountType) => {
-            const account = await getAccountFromAddressUtil(
-                address,
-                privateKey,
-                accountType,
-                hre
-            );
+            const account = await getAccountFromAddressUtil(address, privateKey, accountType, hre);
             return account;
         }
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import {
 } from "./task-actions";
 import {
     bigIntToShortStringUtil,
-    deployAccountFromABIUtil,
+    deployAccountUtil,
     getAccountFromAddressUtil,
     getContractFactoryUtil,
     getWalletUtil,
@@ -196,8 +196,8 @@ extendEnvironment((hre) => {
 
         devnet: lazyObject(() => new DevnetUtils(hre)),
 
-        deployAccountFromABI: async (accountType) => {
-            const account = await deployAccountFromABIUtil(accountType, hre);
+        deployAccount: async (accountType) => {
+            const account = await deployAccountUtil(accountType, hre);
             return account;
         },
 

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -1,6 +1,11 @@
 import "hardhat/types/config";
 import "hardhat/types/runtime";
-import { AccountImplementationType, StarknetContract, StarknetContractFactory, StringMap } from "./types";
+import {
+    AccountImplementationType,
+    StarknetContract,
+    StarknetContractFactory,
+    StringMap
+} from "./types";
 import { StarknetWrapper } from "./starknet-wrappers";
 import { FlushResponse, LoadL1MessagingContractResponse } from "./devnet-utils";
 import { Account } from "./account";
@@ -142,9 +147,7 @@ declare module "hardhat/types/runtime" {
              * @param accountType the enumerator value of the type of Account to use
              * @returns an Account object
              */
-            deployAccountFromABI: (
-                accountType: AccountImplementationType
-            ) => Promise<Account>;
+            deployAccountFromABI: (accountType: AccountImplementationType) => Promise<Account>;
 
             /**
              * Returns an Account already deployed based on the address and validated by the private key

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -147,7 +147,7 @@ declare module "hardhat/types/runtime" {
              * @param accountType the enumerator value of the type of Account to use
              * @returns an Account object
              */
-            deployAccountFromABI: (accountType: AccountImplementationType) => Promise<Account>;
+            deployAccount: (accountType: AccountImplementationType) => Promise<Account>;
 
             /**
              * Returns an Account already deployed based on the address and validated by the private key


### PR DESCRIPTION
## Usage
- Change name of the account deploying function to reflect its purpose.
- Update Readme.

## Dev
None