### PR TITLE
Hotfix for account artifacts, return tx hash on invoke

### DIFF
--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -66,7 +66,7 @@ export async function handleAccountContractArtifacts(
     accountType: string,
     artifactsName: string,
     hre: HardhatRuntimeEnvironment
-) {
+): Promise<string> {
     // Name of the artifacts' parent folder
     const targetPath = artifactsName + ".cairo";
 
@@ -79,19 +79,23 @@ export async function handleAccountContractArtifacts(
     );
 
     if (!fs.existsSync(artifactsTargetPath)) {
-
         // Check if an old version of the artifacts still exists in the path, if so delete it
         const baseArtifactsPath = path.join(
             hre.config.paths.starknetArtifacts,
             ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH
         );
 
-        const contents = fs.readdirSync(baseArtifactsPath);
+        if (fs.existsSync(baseArtifactsPath)) {
+            const contents = fs.readdirSync(baseArtifactsPath);
 
-        if (!(ACCOUNT_ARTIFACTS_VERSION in contents)) {
-            contents.forEach((content) => {
-                fs.rmSync(path.join(baseArtifactsPath, content), { recursive: true, force: true });
-            });
+            if (!(ACCOUNT_ARTIFACTS_VERSION in contents)) {
+                contents.forEach((content) => {
+                    fs.rmSync(path.join(baseArtifactsPath, content), {
+                        recursive: true,
+                        force: true
+                    });
+                });
+            }
         }
 
         const jsonArtifact = artifactsName + ".json";
@@ -109,6 +113,8 @@ export async function handleAccountContractArtifacts(
         await downloadArtifact(jsonArtifact, artifactsTargetPath, fileLocationUrl);
         await downloadArtifact(abiArtifact, artifactsTargetPath, fileLocationUrl);
     }
+
+    return artifactsTargetPath;
 }
 async function downloadArtifact(
     artifactName: string,

--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -98,29 +98,36 @@ export async function handleAccountContractArtifacts(
     const jsonArtifact = artifactsName + ".json";
     const abiArtifact = artifactsName + ABI_SUFFIX;
 
-    const fileLocationUrl = GITHUB_ACCOUNT_ARTIFACTS_URL.concat(
+    const artifactLocationUrl = GITHUB_ACCOUNT_ARTIFACTS_URL.concat(
         accountType,
         "/",
         artifactsBase,
         "/"
     );
 
-    await assertArtifact(jsonArtifact, artifactsTargetPath, fileLocationUrl);
-    await assertArtifact(abiArtifact, artifactsTargetPath, fileLocationUrl);
+    await assertArtifact(jsonArtifact, artifactsTargetPath, artifactLocationUrl);
+    await assertArtifact(abiArtifact, artifactsTargetPath, artifactLocationUrl);
 
     return artifactsTargetPath;
 }
 
+/**
+ * Checks if the provided artifact exists in the project's artifacts folder.
+ * If it doesen't, downloads it from the GitHub repository "https://github.com/Shard-Labs/starknet-hardhat-example"
+ * @param artifact artifact file to download. E.g. "Account.json" or "Account_abi.json"
+ * @param artifactsTargetPath folder to where the artifacts will be downloaded. E.g. "project/starknet-artifacts/Account.cairo"
+ * @param artifactLocationUrl url to the github folder where the artifacts are stored
+ */
 async function assertArtifact(
     artifact: string,
     artifactsTargetPath: string,
-    fileLocationUrl: string
+    artifactLocationUrl: string
 ) {
+    // Download artifact if it doesen't exist
     if (!fs.existsSync(path.join(artifactsTargetPath, artifact))) {
-        // Check if an old version of the artifacts still exists in the path, if so delete it
         fs.mkdirSync(artifactsTargetPath, { recursive: true });
 
-        const rawFileURL = fileLocationUrl.concat(artifact);
+        const rawFileURL = artifactLocationUrl.concat(artifact);
 
         const response = await axios.get(rawFileURL, {
             transformResponse: (res) => {

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,4 +1,4 @@
-import { Choice, StarknetContract, StringMap } from "./types";
+import { Choice, InvokeResponse, StarknetContract, StringMap } from "./types";
 import { PLUGIN_NAME } from "./constants";
 import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
@@ -11,8 +11,6 @@ import {
     handleAccountContractArtifacts,
     sign
 } from "./account-utils";
-
-type InvokeResponse = string;
 
 /**
  * Representation of an Account.
@@ -155,15 +153,13 @@ export class OpenZeppelinAccount extends Account {
         privateKey: string,
         hre: HardhatRuntimeEnvironment
     ): Promise<Account> {
-        await handleAccountContractArtifacts(
+        const contractPath = await handleAccountContractArtifacts(
             OpenZeppelinAccount.ACCOUNT_TYPE_NAME,
             OpenZeppelinAccount.ACCOUNT_ARTIFACTS_NAME,
             hre
         );
 
-        const contractFactory = await hre.starknet.getContractFactory(
-            OpenZeppelinAccount.ACCOUNT_ARTIFACTS_NAME
-        );
+        const contractFactory = await hre.starknet.getContractFactory(contractPath);
         const contract = contractFactory.getContractAt(address);
 
         const { res: expectedPubKey } = await contract.call("get_public_key");

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,17 +1,18 @@
 import { Choice, StarknetContract, StringMap } from "./types";
-import { ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH, PLUGIN_NAME } from "./constants";
+import { PLUGIN_NAME } from "./constants";
 import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { hash } from "starknet";
 import * as ellipticCurve from "starknet/utils/ellipticCurve";
 import { toBN } from "starknet/utils/number";
 import { ec } from "elliptic";
-import path from "path";
 import {
     generateRandomStarkPrivateKey,
     handleAccountContractArtifacts,
     sign
 } from "./account-utils";
+
+type InvokeResponse = string;
 
 /**
  * Representation of an Account.
@@ -36,7 +37,7 @@ export abstract class Account {
         toContract: StarknetContract,
         functionName: string,
         calldata?: StringMap
-    ): Promise<string>;
+    ): Promise<InvokeResponse>;
 
     /**
      * Uses the account contract as a proxy to call a function on the target contract with a signature
@@ -79,7 +80,7 @@ export class OpenZeppelinAccount extends Account {
         toContract: StarknetContract,
         functionName: string,
         calldata: StringMap = {}
-    ): Promise<string> {
+    ): Promise<InvokeResponse> {
         return (await this.invokeOrCall("invoke", toContract, functionName, calldata)).toString();
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,8 @@ export type TxStatus =
 // Types of account implementations
 export type AccountImplementationType = "OpenZeppelin";
 
+export type InvokeResponse = string;
+
 export type StarknetContractFactoryConfig = StarknetContractConfig & {
     metadataPath: string;
 };
@@ -419,7 +421,7 @@ export class StarknetContract {
         functionName: string,
         args?: StringMap,
         options: InvokeOptions = {}
-    ): Promise<string> {
+    ): Promise<InvokeResponse> {
         const executed = await this.invokeOrCall("invoke", functionName, args, options);
         const txHash = extractTxHash(executed.stdout.toString());
 

--- a/test/general-tests/account-test/check.sh
+++ b/test/general-tests/account-test/check.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 set -e
 
-DUMMY_DIR=starknet-artifacts/account-contract-artifacts/0.0.0/Account.cairo
-
-mkdir -p "$DUMMY_DIR"
-
 npx hardhat starknet-compile contracts/contract.cairo
 
 npx hardhat test --no-compile test/account-test.ts
-
-echo "Testing removal of dummy directory"
-if [ -d "$DUMMY_DIR" ]; then
-    # If path exists, exit with an error because it should have been deleted while fetching the correct artifacts
-    exit 1
-fi
-echo "Success"


### PR DESCRIPTION
## Usage related changes
- Users no longer need to explicitly create a `starknet-artifacts/account-contract-artifacts` folder to avoid the error `Error: ENOENT: no such file or directory`

## Development related changes
- Check if the account artifacts exist before accessing the folder;
- Account invoke() return is of type `type InvokeResponse = string`, and it returns the transaction hash of the invoke.


# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have documented the changes

