### PR TITLE
Adapt to 0.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ commands:
                   command: echo $(curl -Ls https://api.github.com/repos/Shard-Labs/starknet-devnet/commits/master | jq -r .sha) > /tmp/devnet-version
             - run:
                   name: "Set cairo-lang version"
-                  command: echo 0.7.1 > /tmp/cairo-lang-version
+                  command: echo 0.8.0 > /tmp/cairo-lang-version
     restore_dependency_cache:
         parameters:
             platform:

--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -151,8 +151,8 @@ export async function handleAccountContractArtifacts(
         "/"
     );
 
-    await assertArtifact(jsonArtifact, artifactsTargetPath, artifactLocationUrl);
-    await assertArtifact(abiArtifact, artifactsTargetPath, artifactLocationUrl);
+    await ensureArtifact(jsonArtifact, artifactsTargetPath, artifactLocationUrl);
+    await ensureArtifact(abiArtifact, artifactsTargetPath, artifactLocationUrl);
 
     return artifactsTargetPath;
 }
@@ -164,7 +164,7 @@ export async function handleAccountContractArtifacts(
  * @param artifactsTargetPath folder to where the artifacts will be downloaded. E.g. "project/starknet-artifacts/Account.cairo"
  * @param artifactLocationUrl url to the github folder where the artifacts are stored
  */
-async function assertArtifact(
+async function ensureArtifact(
     artifact: string,
     artifactsTargetPath: string,
     artifactLocationUrl: string

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,4 +1,4 @@
-import { Choice, InvokeResponse, StarknetContract, StringMap } from "./types";
+import { ExecutionChoice, InvokeResponse, StarknetContract, StringMap } from "./types";
 import { PLUGIN_NAME } from "./constants";
 import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
@@ -60,7 +60,7 @@ export abstract class Account {
     }
 
     private async invokeOrCall(
-        choice: Choice,
+        choice: ExecutionChoice,
         toContract: StarknetContract,
         functionName: string,
         calldata?: StringMap
@@ -97,7 +97,7 @@ export abstract class Account {
         return (await this.multiInvokeOrMultiCall("invoke", callParameters)).toString();
     }
 
-    async multiInvokeOrMultiCall(choice: Choice, callParameters: CallParameters[]) {
+    async multiInvokeOrMultiCall(choice: ExecutionChoice, callParameters: CallParameters[]) {
         const nonce = await this.getNonce();
 
         const { messageHash, args } = handleMultiCall(
@@ -109,8 +109,9 @@ export abstract class Account {
         const signatures = this.getSignatures(messageHash);
         const options = { signature: signatures };
 
+        const contractInteractor = this.starknetContract[choice];
         const executionFunctionName = this.getExecutionFunctionName();
-        return await this.starknetContract[choice](executionFunctionName, args, options);
+        return contractInteractor(executionFunctionName, args, options);
     }
 
     abstract getSignatures(messageHash: string): bigint[];

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,4 +1,4 @@
-import { ExecutionChoice, InvokeResponse, StarknetContract, StringMap } from "./types";
+import { ExecuteChoice, InvokeResponse, StarknetContract, StringMap } from "./types";
 import { PLUGIN_NAME } from "./constants";
 import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
@@ -60,7 +60,7 @@ export abstract class Account {
     }
 
     private async invokeOrCall(
-        choice: ExecutionChoice,
+        choice: ExecuteChoice,
         toContract: StarknetContract,
         functionName: string,
         calldata?: StringMap
@@ -97,7 +97,7 @@ export abstract class Account {
         return (await this.multiInvokeOrMultiCall("invoke", callParameters)).toString();
     }
 
-    async multiInvokeOrMultiCall(choice: ExecutionChoice, callParameters: CallParameters[]) {
+    async multiInvokeOrMultiCall(choice: ExecuteChoice, callParameters: CallParameters[]) {
         const nonce = await this.getNonce();
 
         const { messageHash, args } = handleMultiCall(

--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -7,7 +7,15 @@ function isNumeric(value: { toString: () => string }) {
     if (value === undefined || value === null) {
         return false;
     }
-    return /^-?\d+$/.test(value.toString());
+    const strValue = value.toString();
+
+    const decimalRegex = /^-?\d+$/;
+    const hexadecimalRegex = /^0x[0-9a-fA-F]+?$/;
+    return decimalRegex.test(strValue) || hexadecimalRegex.test(strValue);
+}
+
+function convertToNumeric(value: { toString: () => string }) {
+    return BigInt(value.toString()).toString();
 }
 
 /**
@@ -65,7 +73,7 @@ export function adaptInputUtil(
         if (inputSpec.type === "felt") {
             const errorMsg = `${functionName}: Expected ${inputSpec.name} to be a felt`;
             if (isNumeric(currentValue)) {
-                adapted.push(currentValue.toString());
+                adapted.push(convertToNumeric(currentValue));
             } else if (inputSpec.name.endsWith(LEN_SUFFIX)) {
                 const nextSpec = inputSpecs[i + 1];
                 const arrayName = inputSpec.name.slice(0, -LEN_SUFFIX.length);
@@ -136,7 +144,7 @@ function adaptComplexInput(
 
     if (type === "felt") {
         if (isNumeric(input)) {
-            adaptedArray.push(input.toString());
+            adaptedArray.push(convertToNumeric(input));
             return;
         }
         const msg = `Expected ${inputSpec.name} to be a felt`;

--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -14,7 +14,7 @@ function isNumeric(value: { toString: () => string }) {
     return decimalRegex.test(strValue) || hexadecimalRegex.test(strValue);
 }
 
-function convertToNumeric(value: { toString: () => string }) {
+function toNumericString(value: { toString: () => string }) {
     return BigInt(value.toString()).toString();
 }
 
@@ -73,7 +73,7 @@ export function adaptInputUtil(
         if (inputSpec.type === "felt") {
             const errorMsg = `${functionName}: Expected ${inputSpec.name} to be a felt`;
             if (isNumeric(currentValue)) {
-                adapted.push(convertToNumeric(currentValue));
+                adapted.push(toNumericString(currentValue));
             } else if (inputSpec.name.endsWith(LEN_SUFFIX)) {
                 const nextSpec = inputSpecs[i + 1];
                 const arrayName = inputSpec.name.slice(0, -LEN_SUFFIX.length);
@@ -144,7 +144,7 @@ function adaptComplexInput(
 
     if (type === "felt") {
         if (isNumeric(input)) {
-            adaptedArray.push(convertToNumeric(input));
+            adaptedArray.push(toNumericString(input));
             return;
         }
         const msg = `Expected ${inputSpec.name} to be a felt`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@ export const DEFAULT_STARKNET_SOURCES_PATH = "contracts";
 export const DEFAULT_STARKNET_ARTIFACTS_PATH = "starknet-artifacts";
 export const DEFAULT_STARKNET_ACCOUNT_PATH = "~/.starknet_accounts";
 export const DOCKER_REPOSITORY = "shardlabs/cairo-cli";
-export const DEFAULT_DOCKER_IMAGE_TAG = "0.7.1";
+export const DEFAULT_DOCKER_IMAGE_TAG = "0.8.0";
 
 export const ACCOUNT_CONTRACT_ARTIFACTS_ROOT_PATH = "account-contract-artifacts";
 export const ACCOUNT_ARTIFACTS_VERSION = "0.2.0";

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,8 @@ import {
     starknetInvokeAction,
     starknetCallAction,
     starknetDeployAccountAction,
-    starknetTestAction
+    starknetTestAction,
+    starknetEstimateFeeAction
 } from "./task-actions";
 import {
     bigIntToShortStringUtil,
@@ -260,6 +261,28 @@ task("starknet-call", "Invokes a function on a contract in the provided address.
         "The number of the block to call. If omitted, the pending block will be queried."
     )
     .setAction(starknetCallAction);
+
+task("starknet-estimate-fee", "Estimates the gas fee of a function execution.")
+    .addOptionalParam("starknetNetwork", "The network version to be used (e.g. alpha)")
+    .addOptionalParam("gatewayUrl", `The URL of the gateway to be used (e.g. ${ALPHA_URL})`)
+    .addParam("contract", "The name of the contract to invoke from")
+    .addParam("function", "The name of the function to invoke")
+    .addParam("address", "The address where the contract is deployed")
+    .addOptionalParam(
+        "inputs",
+        "Space separated values forming function input.\n" +
+            `Pass them as a single string; e.g. --inputs "${"1 2 3"}"`
+    )
+    .addOptionalParam("signature", "The call signature")
+    .addOptionalParam(
+        "wallet",
+        "The wallet to use, defined in the 'hardhat.config' file. If omitted, the '--no_wallet' flag will be passed when calling."
+    )
+    .addOptionalParam(
+        "blockNumber",
+        "The number of the block to call. If omitted, the pending block will be queried."
+    )
+    .setAction(starknetEstimateFeeAction);
 
 task("starknet-deploy-account", "Deploys a new account according to the parameters.")
     .addParam("wallet", "The wallet object to use, defined in the 'hardhat.config' file")

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { HardhatPluginError } from "hardhat/plugins";
 import * as path from "path";
 import { PLUGIN_NAME } from "./constants";
-import { InteractionChoice } from "./types";
+import { InteractChoice } from "./types";
 import { adaptUrl } from "./utils";
 
 interface CompileWrapperOptions {
@@ -21,8 +21,8 @@ interface DeployWrapperOptions {
     salt?: string;
 }
 
-interface InvokeOrCallWrapperOptions {
-    choice: InteractionChoice;
+interface InteractWrapperOptions {
+    choice: InteractChoice;
     address: string;
     abi: string;
     functionName: string;
@@ -89,7 +89,7 @@ export abstract class StarknetWrapper {
 
     public abstract deploy(options: DeployWrapperOptions): Promise<ProcessResult>;
 
-    protected prepareInvokeOrCallOptions(options: InvokeOrCallWrapperOptions): string[] {
+    protected prepareInteractOptions(options: InteractWrapperOptions): string[] {
         const prepared = [
             options.choice,
             "--abi",
@@ -132,7 +132,7 @@ export abstract class StarknetWrapper {
         return prepared;
     }
 
-    public abstract invokeOrCall(options: InvokeOrCallWrapperOptions): Promise<ProcessResult>;
+    public abstract interact(options: InteractWrapperOptions): Promise<ProcessResult>;
 
     protected prepareGetTxStatusOptions(options: GetTxStatusWrapperOptions): string[] {
         return [
@@ -275,7 +275,7 @@ export class DockerWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async invokeOrCall(options: InvokeOrCallWrapperOptions): Promise<ProcessResult> {
+    public async interact(options: InteractWrapperOptions): Promise<ProcessResult> {
         const binds: String2String = {
             [options.abi]: options.abi
         };
@@ -291,7 +291,7 @@ export class DockerWrapper extends StarknetWrapper {
 
         options.gatewayUrl = adaptUrl(options.gatewayUrl);
         options.feederGatewayUrl = adaptUrl(options.feederGatewayUrl);
-        const preparedOptions = this.prepareInvokeOrCallOptions(options);
+        const preparedOptions = this.prepareInteractOptions(options);
         const docker = await this.getDocker();
         const executed = await docker.runContainer(
             this.image,
@@ -402,8 +402,8 @@ export class VenvWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async invokeOrCall(options: InvokeOrCallWrapperOptions): Promise<ProcessResult> {
-        const preparedOptions = this.prepareInvokeOrCallOptions(options);
+    public async interact(options: InteractWrapperOptions): Promise<ProcessResult> {
+        const preparedOptions = this.prepareInteractOptions(options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { HardhatPluginError } from "hardhat/plugins";
 import * as path from "path";
 import { PLUGIN_NAME } from "./constants";
-import { Choice } from "./types";
+import { InteractionChoice } from "./types";
 import { adaptUrl } from "./utils";
 
 interface CompileWrapperOptions {
@@ -22,7 +22,7 @@ interface DeployWrapperOptions {
 }
 
 interface InvokeOrCallWrapperOptions {
-    choice: Choice;
+    choice: InteractionChoice;
     address: string;
     abi: string;
     functionName: string;

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -91,7 +91,7 @@ export abstract class StarknetWrapper {
 
     protected prepareInteractOptions(options: InteractWrapperOptions): string[] {
         const prepared = [
-            options.choice,
+            options.choice.cliCommand,
             "--abi",
             options.abi,
             "--feeder_gateway_url",

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import axios from "axios";
 import { HardhatPluginError } from "hardhat/plugins";
 import { PLUGIN_NAME, ABI_SUFFIX, ALPHA_TESTNET, DEFAULT_STARKNET_NETWORK } from "./constants";
-import { iterativelyCheckStatus, extractTxHash, InteractionChoice } from "./types";
+import { iterativelyCheckStatus, extractTxHash, InteractChoice } from "./types";
 import { ProcessResult } from "@nomiclabs/hardhat-docker";
 import {
     adaptLog,
@@ -369,15 +369,19 @@ function handleMultiPartContractVerification(
 }
 
 export async function starknetInvokeAction(args: TaskArguments, hre: HardhatRuntimeEnvironment) {
-    await starknetInvokeOrCallAction("invoke", args, hre);
+    await starknetInteractAction("invoke", args, hre);
 }
 
 export async function starknetCallAction(args: TaskArguments, hre: HardhatRuntimeEnvironment) {
-    await starknetInvokeOrCallAction("call", args, hre);
+    await starknetInteractAction("call", args, hre);
 }
 
-async function starknetInvokeOrCallAction(
-    choice: InteractionChoice,
+export async function starknetEstimateFeeAction(args: TaskArguments, hre: HardhatRuntimeEnvironment) {
+    await starknetInteractAction("estimate_fee", args, hre);
+}
+
+async function starknetInteractAction(
+    choice: InteractChoice,
     args: TaskArguments,
     hre: HardhatRuntimeEnvironment
 ) {
@@ -391,7 +395,7 @@ async function starknetInvokeOrCallAction(
         accountDir = getAccountPath(wallet.accountPath, hre);
     }
 
-    const executed = await hre.starknetWrapper.invokeOrCall({
+    const executed = await hre.starknetWrapper.interact({
         choice: choice,
         address: args.address,
         abi: abiPath,

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -369,18 +369,18 @@ function handleMultiPartContractVerification(
 }
 
 export async function starknetInvokeAction(args: TaskArguments, hre: HardhatRuntimeEnvironment) {
-    await starknetInteractAction("invoke", args, hre);
+    await starknetInteractAction(InteractChoice.INVOKE, args, hre);
 }
 
 export async function starknetCallAction(args: TaskArguments, hre: HardhatRuntimeEnvironment) {
-    await starknetInteractAction("call", args, hre);
+    await starknetInteractAction(InteractChoice.CALL, args, hre);
 }
 
 export async function starknetEstimateFeeAction(
     args: TaskArguments,
     hre: HardhatRuntimeEnvironment
 ) {
-    await starknetInteractAction("estimate_fee", args, hre);
+    await starknetInteractAction(InteractChoice.ESTIMATE_FEE, args, hre);
 }
 
 async function starknetInteractAction(
@@ -422,7 +422,7 @@ async function starknetInteractAction(
         throw new HardhatPluginError(PLUGIN_NAME, replacedMsg);
     }
 
-    if (choice === "invoke" && args.wait) {
+    if (choice === InteractChoice.INVOKE && args.wait) {
         // If the "wait" flag was passed as an argument, check the transaction hash for its status
         console.log(`Checking ${choice} transaction...`);
         const executedOutput = executed.stdout.toString();

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -376,7 +376,10 @@ export async function starknetCallAction(args: TaskArguments, hre: HardhatRuntim
     await starknetInteractAction("call", args, hre);
 }
 
-export async function starknetEstimateFeeAction(args: TaskArguments, hre: HardhatRuntimeEnvironment) {
+export async function starknetEstimateFeeAction(
+    args: TaskArguments,
+    hre: HardhatRuntimeEnvironment
+) {
     await starknetInteractAction("estimate_fee", args, hre);
 }
 

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -417,14 +417,16 @@ async function starknetInteractAction(
     const statusCode = processExecuted(executed, true);
 
     if (statusCode) {
-        const msg = `Could not ${choice} ${args.function}:\n` + executed.stderr.toString();
+        const msg =
+            `Could not perform ${choice.cliCommand} of ${args.function}:\n` +
+            executed.stderr.toString();
         const replacedMsg = adaptLog(msg);
         throw new HardhatPluginError(PLUGIN_NAME, replacedMsg);
     }
 
     if (choice === InteractChoice.INVOKE && args.wait) {
         // If the "wait" flag was passed as an argument, check the transaction hash for its status
-        console.log(`Checking ${choice} transaction...`);
+        console.log("Checking transaction...");
         const executedOutput = executed.stdout.toString();
         const txHash = extractTxHash(executedOutput);
         await new Promise<void>((resolve, reject) =>

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import axios from "axios";
 import { HardhatPluginError } from "hardhat/plugins";
 import { PLUGIN_NAME, ABI_SUFFIX, ALPHA_TESTNET, DEFAULT_STARKNET_NETWORK } from "./constants";
-import { iterativelyCheckStatus, extractTxHash, Choice } from "./types";
+import { iterativelyCheckStatus, extractTxHash, InteractionChoice } from "./types";
 import { ProcessResult } from "@nomiclabs/hardhat-docker";
 import {
     adaptLog,
@@ -377,7 +377,7 @@ export async function starknetCallAction(args: TaskArguments, hre: HardhatRuntim
 }
 
 async function starknetInvokeOrCallAction(
-    choice: Choice,
+    choice: InteractionChoice,
     args: TaskArguments,
     hre: HardhatRuntimeEnvironment
 ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,18 +209,14 @@ function handleSignature(signature: Array<Numeric>): string[] {
 }
 
 function parseFeeEstimation(raw: string): FeeEstimation {
-    for (const regex of [
-        /^\s*\{\s*"amount"\s*:\s*(?<amount>.*)\s*,\s*"unit"\s*:\s*"(?<unit>.*)"\s*\}\s*$/,
-        /^\s*\{\s*"unit"\s*:\s*(?<unit>.*)\s*,\s*"amount"\s*:\s*"(?<amount>.*)"\s*\}\s*$/
-    ]) {
-        const matched = raw.match(regex);
-        if (matched) {
-            return {
-                amount: BigInt(matched.groups.amount),
-                unit: matched.groups.unit
-            };
-        }
+    const matched = raw.match(/^The estimated fee is: (?<amount>.*) WEI \(.* ETH\)\./);
+    if (matched) {
+        return {
+            amount: BigInt(matched.groups.amount),
+            unit: "wei"
+        };
     }
+    throw new HardhatPluginError(PLUGIN_NAME, "Cannot parse fee estimation response.");
 }
 
 export interface DeployOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,7 +208,7 @@ function handleSignature(signature: Array<Numeric>): string[] {
     return [];
 }
 
-function parseFeeEstimation(raw: string): FeeEstimation {
+export function parseFeeEstimation(raw: string): FeeEstimation {
     const matched = raw.match(/^The estimated fee is: (?<amount>.*) WEI \(.* ETH\)\./);
     if (matched) {
         return {

--- a/test/configuration-tests/with-cairo-version/hardhat.config.ts
+++ b/test/configuration-tests/with-cairo-version/hardhat.config.ts
@@ -2,7 +2,7 @@ import "../dist/index.js";
 
 module.exports = {
     starknet: {
-        dockerizedVersion: "0.7.1",
+        dockerizedVersion: "0.8.0",
         network: process.env.NETWORK
     },
     networks: {

--- a/test/general-tests/starknet-call/no-inputs.txt
+++ b/test/general-tests/starknet-call/no-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not call sum_points_to_tuple:
+Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
 Error: AssertionError: Expected at least 4 inputs, got 0.
 
 

--- a/test/general-tests/starknet-call/too-few-inputs.txt
+++ b/test/general-tests/starknet-call/too-few-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not call sum_points_to_tuple:
+Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
 Error: AssertionError: Expected at least 4 inputs, got 3.
 
 

--- a/test/general-tests/starknet-call/too-many-inputs.txt
+++ b/test/general-tests/starknet-call/too-many-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not call sum_points_to_tuple:
+Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
 Error: AssertionError: Wrong number of arguments. Expected 4, got 5.
 
 

--- a/test/general-tests/starknet-estimate-fee/check.sh
+++ b/test/general-tests/starknet-estimate-fee/check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+npx hardhat starknet-compile contracts/contract.cairo
+output=$(npx hardhat starknet-deploy --starknet-network "$NETWORK" starknet-artifacts/contracts/contract.cairo/ --inputs 10)
+echo $output
+
+ADDRESS=$(echo $output | sed -r "s/.*Contract address: (\w*).*/\1/")
+PREFIX=$(dirname "$0")
+
+echo "Testing no input argument"
+npx hardhat starknet-estimate-fee --starknet-network "$NETWORK" --contract contract --function sum_points_to_tuple --address "$ADDRESS" 2>&1 \
+    | tail -n +6 \
+    | diff - "$PREFIX/no-inputs.txt"
+echo "Success"
+
+echo "Testing too few input arguments"
+npx hardhat starknet-estimate-fee --starknet-network "$NETWORK" --contract contract --function sum_points_to_tuple --address "$ADDRESS" --inputs "10 20 30" 2>&1 \
+    | tail -n +6 \
+    | diff - "$PREFIX/too-few-inputs.txt"
+echo "Success"
+
+echo "Testing too many input arguments"
+npx hardhat starknet-estimate-fee --starknet-network "$NETWORK" --contract contract --function sum_points_to_tuple --address "$ADDRESS" --inputs "10 20 30 40 50" 2>&1 \
+    | tail -n +6 \
+    | diff - "$PREFIX/too-many-inputs.txt"
+echo "Success"
+
+echo "The success case of starknet-estimate-fee test is temporarily disabled."
+echo "To enable it back, uncomment the lines in its check.sh."
+# echo "Testing success case"
+# npx hardhat starknet-estimate-fee --starknet-network "$NETWORK" --contract contract --function sum_points_to_tuple --address "$ADDRESS" --inputs "10 20 30 40" 2>&1 \
+#     | tail -n +2 \
+#     | head -n -3 \
+#     | diff - <(echo "40 60")
+# echo "Success"

--- a/test/general-tests/starknet-estimate-fee/hardhat.config.ts
+++ b/test/general-tests/starknet-estimate-fee/hardhat.config.ts
@@ -1,0 +1,12 @@
+import "../dist/index.js";
+
+module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
+    networks: {
+        devnet: {
+            url: "http://localhost:5000"
+        }
+    }
+};

--- a/test/general-tests/starknet-estimate-fee/no-inputs.txt
+++ b/test/general-tests/starknet-estimate-fee/no-inputs.txt
@@ -1,0 +1,5 @@
+Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
+Error: AssertionError: Expected at least 4 inputs, got 0.
+
+
+For more info run Hardhat with --show-stack-traces

--- a/test/general-tests/starknet-estimate-fee/too-few-inputs.txt
+++ b/test/general-tests/starknet-estimate-fee/too-few-inputs.txt
@@ -1,0 +1,5 @@
+Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
+Error: AssertionError: Expected at least 4 inputs, got 3.
+
+
+For more info run Hardhat with --show-stack-traces

--- a/test/general-tests/starknet-estimate-fee/too-many-inputs.txt
+++ b/test/general-tests/starknet-estimate-fee/too-many-inputs.txt
@@ -1,0 +1,5 @@
+Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
+Error: AssertionError: Wrong number of arguments. Expected 4, got 5.
+
+
+For more info run Hardhat with --show-stack-traces

--- a/test/general-tests/starknet-invoke/no-inputs.txt
+++ b/test/general-tests/starknet-invoke/no-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not invoke increase_balance:
+Error in plugin Starknet: Could not perform invoke of increase_balance:
 Error: AssertionError: Expected at least 1 inputs, got 0.
 
 

--- a/test/general-tests/starknet-invoke/too-few-inputs.txt
+++ b/test/general-tests/starknet-invoke/too-few-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not invoke increase_balance:
+Error in plugin Starknet: Could not perform invoke of increase_balance:
 Error: AssertionError: Expected at least 2 inputs, got 1.
 
 

--- a/test/general-tests/starknet-invoke/too-many-inputs.txt
+++ b/test/general-tests/starknet-invoke/too-many-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not invoke increase_balance:
+Error in plugin Starknet: Could not perform invoke of increase_balance:
 Error: AssertionError: Wrong number of arguments. Expected 2, got 3.
 
 


### PR DESCRIPTION
## Usage related changes
- Introduce `hardhat starknet-estimate-fee`.
- Introduce `StarknetContract.estimateFee`.
- Use `0.8.0` docker version by default`.
- Support hex strings as contract function input.

## Development related changes
- Make `Choice` more refined:
  - Distinguish between:
    - `ExecuteChoice = "invoke" | "call"`
    - `InteractChoice = ExecuteChoice | estimate_fee`
  - Rationale:
    - `estimate_fee` can reuse a lot of old code

## Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [ ] I have documented the changes
- [x] I have updated the tests
- [x] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
