### PR TITLE
Added getTransaction and getTransaction receipt functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,10 +326,27 @@ Exchanging messages between L1 (Ganache, hardhat node, Ethereum testnet) and L2 
 ### Test - fee estimation
 
 ```typescript
-  it("should estimate fee", async function () {
+it("should estimate fee", async function () {
     const fee = contract.estimateFee("increase_balance", { amount: 10n });
     console.log("Estimated fee:", fee.amount, fee.unit);
-  });
+});
+```
+
+### Test - transaction information and receipt
+
+```typescript
+it("should return transaction data and transaction receipt", async function () {
+    const contract: StarknetContract = await contractFactory.deploy();
+    console.log("Deployment transaction hash:", contract.deployTxHash);
+
+    const transaction = await starknet.getTransaction(contract.deployTxHash);
+    console.log(transaction);
+
+    const txHash = await contract.invoke("increase_balance", { amount: 10 });
+
+    const receipt = await starknet.getTransactionReceipt(txHash);
+    console.log(receipt);
+});
 ```
 
 For more usage examples, including tuple, array and struct support, as well as wallet support, check [sample-test.ts](https://github.com/Shard-Labs/starknet-hardhat-example/blob/master/test/sample-test.ts) of [starknet-hardhat-example](https://github.com/Shard-Labs/starknet-hardhat-example).

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -3,8 +3,9 @@ import { HardhatPluginError } from "hardhat/plugins";
 import { Devnet, HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { PLUGIN_NAME } from "./constants";
+import { L2ToL1Message } from "./starknet-types";
 
-interface L1Message {
+interface L1ToL2Message {
     address: string;
     args: {
         from_address: string;
@@ -21,17 +22,11 @@ interface L1Message {
     transactionIndex: number;
 }
 
-interface L2Message {
-    from_address: string;
-    to_address: string;
-    payload: Array<string>;
-}
-
 export interface FlushResponse {
     l1_provider: string;
     consumed_messages: {
-        from_l1: Array<L1Message>;
-        from_l2: Array<L2Message>;
+        from_l1: Array<L1ToL2Message>;
+        from_l2: Array<L2ToL1Message>;
     };
 }
 

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -6,6 +6,7 @@ import { ABI_SUFFIX, PLUGIN_NAME, SHORT_STRING_MAX_CHARACTERS } from "./constant
 import { AccountImplementationType, StarknetContractFactory } from "./types";
 import { Account, ArgentAccount, OpenZeppelinAccount } from "./account";
 import { checkArtifactExists, findPath, getAccountPath } from "./utils";
+import { Transaction, TransactionReceipt } from "./starknet-types";
 
 export async function getContractFactoryUtil(hre: HardhatRuntimeEnvironment, contractPath: string) {
     const artifactsPath = hre.config.paths.starknetArtifacts;
@@ -126,4 +127,38 @@ export async function getAccountFromAddressUtil(
     }
 
     return account;
+}
+
+export async function getTransactionUtil(
+    txHash: string,
+    hre: HardhatRuntimeEnvironment
+): Promise<Transaction> {
+    const executed = await hre.starknetWrapper.getTransaction({
+        feederGatewayUrl: hre.config.starknet.networkUrl,
+        gatewayUrl: hre.config.starknet.networkUrl,
+        hash: txHash
+    });
+    if (executed.statusCode) {
+        const msg = `Could not get the transaction. Error: ${executed.stderr.toString()}`;
+        throw new HardhatPluginError(PLUGIN_NAME, msg);
+    }
+    const txReceipt = JSON.parse(executed.stdout.toString()) as Transaction;
+    return txReceipt;
+}
+
+export async function getTxReceiptUtil(
+    txHash: string,
+    hre: HardhatRuntimeEnvironment
+): Promise<TransactionReceipt> {
+    const executed = await hre.starknetWrapper.getTxReceipt({
+        feederGatewayUrl: hre.config.starknet.networkUrl,
+        gatewayUrl: hre.config.starknet.networkUrl,
+        hash: txHash
+    });
+    if (executed.statusCode) {
+        const msg = `Could not get the transaction receipt. Error: ${executed.stderr.toString()}`;
+        throw new HardhatPluginError(PLUGIN_NAME, msg);
+    }
+    const txReceipt = JSON.parse(executed.stdout.toString()) as TransactionReceipt;
+    return txReceipt;
 }

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -139,7 +139,7 @@ export async function getTransactionUtil(
         hash: txHash
     });
     if (executed.statusCode) {
-        const msg = `Could not get the transaction. Error: ${executed.stderr.toString()}`;
+        const msg = `Could not get the transaction. ${executed.stderr.toString()}`;
         throw new HardhatPluginError(PLUGIN_NAME, msg);
     }
     const txReceipt = JSON.parse(executed.stdout.toString()) as Transaction;

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -146,11 +146,11 @@ export async function getTransactionUtil(
     return txReceipt;
 }
 
-export async function getTxReceiptUtil(
+export async function getTransactionReceiptUtil(
     txHash: string,
     hre: HardhatRuntimeEnvironment
 ): Promise<TransactionReceipt> {
-    const executed = await hre.starknetWrapper.getTxReceipt({
+    const executed = await hre.starknetWrapper.getTransactionReceipt({
         feederGatewayUrl: hre.config.starknet.networkUrl,
         gatewayUrl: hre.config.starknet.networkUrl,
         hash: txHash

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import {
     getAccountFromAddressUtil,
     getContractFactoryUtil,
     getTransactionUtil,
-    getTxReceiptUtil,
+    getTransactionReceiptUtil,
     getWalletUtil,
     shortStringToBigIntUtil
 } from "./extend-utils";
@@ -214,8 +214,8 @@ extendEnvironment((hre) => {
             return transaction;
         },
 
-        getTxReceipt: async (txHash) => {
-            const txReceipt = await getTxReceiptUtil(txHash, hre);
+        getTransactionReceipt: async (txHash) => {
+            const txReceipt = await getTransactionReceiptUtil(txHash, hre);
             return txReceipt;
         }
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ import {
     deployAccountUtil,
     getAccountFromAddressUtil,
     getContractFactoryUtil,
+    getTransactionUtil,
+    getTxReceiptUtil,
     getWalletUtil,
     shortStringToBigIntUtil
 } from "./extend-utils";
@@ -205,6 +207,16 @@ extendEnvironment((hre) => {
         getAccountFromAddress: async (address, privateKey, accountType) => {
             const account = await getAccountFromAddressUtil(address, privateKey, accountType, hre);
             return account;
+        },
+
+        getTransaction: async (txHash) => {
+            const transaction = await getTransactionUtil(txHash, hre);
+            return transaction;
+        },
+
+        getTxReceipt: async (txHash) => {
+            const txReceipt = await getTxReceiptUtil(txHash, hre);
+            return txReceipt;
         }
     };
 });

--- a/src/starknet-types.ts
+++ b/src/starknet-types.ts
@@ -29,3 +29,60 @@ export type AbiEntry = CairoFunction | Struct;
 export interface Abi {
     [name: string]: AbiEntry;
 }
+
+export interface Event {
+    data: string[];
+    from_address: string;
+    keys: string[];
+}
+
+export interface BuiltinInstanceCounter {
+    bitwise_builtin: number;
+    ec_op_builtin: number;
+    ecdsa_builtin: number;
+    output_builtin: number;
+    pedersen_builtin: number;
+    range_check_builtin: number;
+}
+
+export interface ExecutionResources {
+    builtin_instance_counter: BuiltinInstanceCounter;
+    n_memory_holes: number;
+    n_steps: number;
+}
+
+export interface TransactionReceipt {
+    block_hash: string;
+    block_number: number;
+    events: Event[];
+    execution_resources: ExecutionResources;
+    l2_to_l1_messages: L2ToL1Message[];
+    status: string;
+    transaction_hash: string;
+    transaction_index: number;
+}
+
+export interface L2ToL1Message {
+    from_address: string;
+    payload: string[];
+    to_address: string;
+}
+
+export interface TransactionData {
+    calldata: string[];
+    contract_address: string;
+    entry_point_selector: string;
+    entry_point_type: string;
+    max_fee: string;
+    signature: string[];
+    transaction_hash: string;
+    type: string;
+}
+
+export interface Transaction {
+    block_hash: string;
+    block_number: number;
+    status: string;
+    transaction: TransactionData;
+    transaction_index: number;
+}

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -134,10 +134,7 @@ export abstract class StarknetWrapper {
 
     public abstract interact(options: InteractWrapperOptions): Promise<ProcessResult>;
 
-    protected prepareGetTxQueryOptions(
-        command: string,
-        options: TxHashQueryWrapperOptions
-    ): string[] {
+    protected prepareTxQueryOptions(command: string, options: TxHashQueryWrapperOptions): string[] {
         return [
             command,
             "--hash",
@@ -181,7 +178,9 @@ export abstract class StarknetWrapper {
 
     public abstract deployAccount(options: DeployAccountWrapperOptions): Promise<ProcessResult>;
 
-    public abstract getTxReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult>;
+    public abstract getTransactionReceipt(
+        options: TxHashQueryWrapperOptions
+    ): Promise<ProcessResult>;
 
     public abstract getTransaction(options: TxHashQueryWrapperOptions): Promise<ProcessResult>;
 }
@@ -317,7 +316,7 @@ export class DockerWrapper extends StarknetWrapper {
             networkMode: "host"
         };
 
-        const preparedOptions = this.prepareGetTxQueryOptions("tx_status", options);
+        const preparedOptions = this.prepareTxQueryOptions("tx_status", options);
 
         const docker = await this.getDocker();
         const executed = await docker.runContainer(
@@ -350,7 +349,7 @@ export class DockerWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async getTxReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
+    public async getTransactionReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
         const binds: String2String = {};
 
         const dockerOptions = {
@@ -358,7 +357,7 @@ export class DockerWrapper extends StarknetWrapper {
             networkMode: "host"
         };
 
-        const preparedOptions = this.prepareGetTxQueryOptions("get_transaction_receipt", options);
+        const preparedOptions = this.prepareTxQueryOptions("get_transaction_receipt", options);
 
         const docker = await this.getDocker();
         const executed = await docker.runContainer(
@@ -377,7 +376,7 @@ export class DockerWrapper extends StarknetWrapper {
             networkMode: "host"
         };
 
-        const preparedOptions = this.prepareGetTxQueryOptions("get_transaction", options);
+        const preparedOptions = this.prepareTxQueryOptions("get_transaction", options);
 
         const docker = await this.getDocker();
         const executed = await docker.runContainer(
@@ -455,7 +454,7 @@ export class VenvWrapper extends StarknetWrapper {
     }
 
     public async getTxStatus(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
-        const preparedOptions = this.prepareGetTxQueryOptions("tx_status", options);
+        const preparedOptions = this.prepareTxQueryOptions("tx_status", options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }
@@ -466,14 +465,14 @@ export class VenvWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async getTxReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
-        const preparedOptions = this.prepareGetTxQueryOptions("get_transaction_receipt", options);
+    public async getTransactionReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
+        const preparedOptions = this.prepareTxQueryOptions("get_transaction_receipt", options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }
 
     public async getTransaction(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
-        const preparedOptions = this.prepareGetTxQueryOptions("get_transaction", options);
+        const preparedOptions = this.prepareTxQueryOptions("get_transaction", options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -37,7 +37,7 @@ interface InteractWrapperOptions {
     blockNumber?: string;
 }
 
-interface GetTxStatusWrapperOptions {
+interface TxHashQueryWrapperOptions {
     hash: string;
     gatewayUrl: string;
     feederGatewayUrl: string;
@@ -134,9 +134,12 @@ export abstract class StarknetWrapper {
 
     public abstract interact(options: InteractWrapperOptions): Promise<ProcessResult>;
 
-    protected prepareGetTxStatusOptions(options: GetTxStatusWrapperOptions): string[] {
+    protected prepareGetTxQueryOptions(
+        command: string,
+        options: TxHashQueryWrapperOptions
+    ): string[] {
         return [
-            "tx_status",
+            command,
             "--hash",
             options.hash,
             "--gateway_url",
@@ -146,7 +149,7 @@ export abstract class StarknetWrapper {
         ];
     }
 
-    public abstract getTxStatus(options: GetTxStatusWrapperOptions): Promise<ProcessResult>;
+    public abstract getTxStatus(options: TxHashQueryWrapperOptions): Promise<ProcessResult>;
 
     protected getPythonDeployAccountScript(options: DeployAccountWrapperOptions): string {
         const wallet = options.wallet ? "'" + options.wallet + "'" : "None";
@@ -175,7 +178,12 @@ export abstract class StarknetWrapper {
         script = script.replace(/(?:\r\n|\r|\n)/g, ";");
         return script;
     }
+
     public abstract deployAccount(options: DeployAccountWrapperOptions): Promise<ProcessResult>;
+
+    public abstract getTxReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult>;
+
+    public abstract getTransaction(options: TxHashQueryWrapperOptions): Promise<ProcessResult>;
 }
 
 function getFullImageName(image: Image): string {
@@ -301,7 +309,7 @@ export class DockerWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async getTxStatus(options: GetTxStatusWrapperOptions): Promise<ProcessResult> {
+    public async getTxStatus(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
         const binds: String2String = {};
 
         const dockerOptions = {
@@ -309,7 +317,7 @@ export class DockerWrapper extends StarknetWrapper {
             networkMode: "host"
         };
 
-        const preparedOptions = this.prepareGetTxStatusOptions(options);
+        const preparedOptions = this.prepareGetTxQueryOptions("tx_status", options);
 
         const docker = await this.getDocker();
         const executed = await docker.runContainer(
@@ -337,6 +345,44 @@ export class DockerWrapper extends StarknetWrapper {
         const executed = await docker.runContainer(
             this.image,
             ["python", "-c", deployAccountScript],
+            dockerOptions
+        );
+        return executed;
+    }
+
+    public async getTxReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
+        const binds: String2String = {};
+
+        const dockerOptions = {
+            binds,
+            networkMode: "host"
+        };
+
+        const preparedOptions = this.prepareGetTxQueryOptions("get_transaction_receipt", options);
+
+        const docker = await this.getDocker();
+        const executed = await docker.runContainer(
+            this.image,
+            ["starknet", ...preparedOptions],
+            dockerOptions
+        );
+        return executed;
+    }
+
+    public async getTransaction(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
+        const binds: String2String = {};
+
+        const dockerOptions = {
+            binds,
+            networkMode: "host"
+        };
+
+        const preparedOptions = this.prepareGetTxQueryOptions("get_transaction", options);
+
+        const docker = await this.getDocker();
+        const executed = await docker.runContainer(
+            this.image,
+            ["starknet", ...preparedOptions],
             dockerOptions
         );
         return executed;
@@ -408,8 +454,8 @@ export class VenvWrapper extends StarknetWrapper {
         return executed;
     }
 
-    public async getTxStatus(options: GetTxStatusWrapperOptions): Promise<ProcessResult> {
-        const preparedOptions = this.prepareGetTxStatusOptions(options);
+    public async getTxStatus(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
+        const preparedOptions = this.prepareGetTxQueryOptions("tx_status", options);
         const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }
@@ -417,6 +463,18 @@ export class VenvWrapper extends StarknetWrapper {
     public async deployAccount(options: DeployAccountWrapperOptions): Promise<ProcessResult> {
         const deployAccountScript = this.getPythonDeployAccountScript(options);
         const executed = await this.execute("python", ["-c", deployAccountScript]);
+        return executed;
+    }
+
+    public async getTxReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
+        const preparedOptions = this.prepareGetTxQueryOptions("get_transaction_receipt", options);
+        const executed = await this.execute(this.starknetPath, preparedOptions);
+        return executed;
+    }
+
+    public async getTransaction(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
+        const preparedOptions = this.prepareGetTxQueryOptions("get_transaction", options);
+        const executed = await this.execute(this.starknetPath, preparedOptions);
         return executed;
     }
 }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -9,6 +9,7 @@ import {
 import { StarknetWrapper } from "./starknet-wrappers";
 import { FlushResponse, LoadL1MessagingContractResponse } from "./devnet-utils";
 import { Account, ArgentAccount, OpenZeppelinAccount } from "./account";
+import { Transaction, TransactionReceipt } from "./starknet-types";
 
 type StarknetConfig = {
     dockerizedVersion?: string;
@@ -65,6 +66,8 @@ type StringMapType = StringMap;
 type AccountType = Account;
 type OpenZeppelinAccountType = OpenZeppelinAccount;
 type ArgentAccountType = ArgentAccount;
+type TransactionReceiptType = TransactionReceipt;
+type TransactionType = Transaction;
 
 declare module "hardhat/types/runtime" {
     interface Devnet {
@@ -162,6 +165,10 @@ declare module "hardhat/types/runtime" {
                 privateKey: string,
                 accountType: AccountImplementationType
             ) => Promise<Account>;
+
+            getTransaction: (txHash: string) => Promise<Transaction>;
+
+            getTxReceipt: (txHash: string) => Promise<TransactionReceipt>;
         };
     }
 
@@ -172,4 +179,6 @@ declare module "hardhat/types/runtime" {
     type Account = AccountType;
     type OpenZeppelinAccount = OpenZeppelinAccountType;
     type ArgentAccount = ArgentAccountType;
+    type Transaction = TransactionType;
+    type TransactionReceipt = TransactionReceiptType;
 }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -168,7 +168,7 @@ declare module "hardhat/types/runtime" {
 
             getTransaction: (txHash: string) => Promise<Transaction>;
 
-            getTxReceipt: (txHash: string) => Promise<TransactionReceipt>;
+            getTransactionReceipt: (txHash: string) => Promise<TransactionReceipt>;
         };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -340,6 +340,7 @@ export class StarknetContractFactory {
             gatewayUrl: this.gatewayUrl
         });
         contract.address = address;
+        contract.deployTxHash = txHash;
 
         return new Promise<StarknetContract>((resolve, reject) => {
             iterativelyCheckStatus(
@@ -404,6 +405,7 @@ export class StarknetContract {
     private gatewayUrl: string;
     private feederGatewayUrl: string;
     private _address: string;
+    public deployTxHash: string;
 
     constructor(config: StarknetContractConfig) {
         this.starknetWrapper = config.starknetWrapper;

--- a/test/general-tests/starknet-estimate-fee/no-inputs.txt
+++ b/test/general-tests/starknet-estimate-fee/no-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
+Error in plugin Starknet: Could not perform estimate_fee of sum_points_to_tuple:
 Error: AssertionError: Expected at least 4 inputs, got 0.
 
 

--- a/test/general-tests/starknet-estimate-fee/too-few-inputs.txt
+++ b/test/general-tests/starknet-estimate-fee/too-few-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
+Error in plugin Starknet: Could not perform estimate_fee of sum_points_to_tuple:
 Error: AssertionError: Expected at least 4 inputs, got 3.
 
 

--- a/test/general-tests/starknet-estimate-fee/too-many-inputs.txt
+++ b/test/general-tests/starknet-estimate-fee/too-many-inputs.txt
@@ -1,4 +1,4 @@
-Error in plugin Starknet: Could not perform call of sum_points_to_tuple:
+Error in plugin Starknet: Could not perform estimate_fee of sum_points_to_tuple:
 Error: AssertionError: Wrong number of arguments. Expected 4, got 5.
 
 


### PR DESCRIPTION
## Usage related changes
-  Implement `getTransaction` and `getTransactionReceipt` functions for the `starknet` object

## Development related changes
- `GetTxStatusWrapperOptions` type was changed to a more generic `TxHashQueryWrapperOptions`, because there are now multiple functions that use the same structure for transaction hash based queries:
-- `prepareGetTxStatusOptions` was changed to `prepareGetTxQueryOptions`, and now takes an additional argument `command` as a parameter;
- `L1Message` and `L2Message` types were changed to `L1ToL2Message` and `L2ToL1Message` respectively to be more clear;

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
