### PR TITLE
Use pyenv in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,6 @@ aliases:
                       key: cairo-lang-cache-{{ arch }}-v1-{{ checksum "/tmp/cairo-lang-version" }}
                       paths:
                           - /usr/python3.8/dist-packages/cairo-lang
-                          - /usr/python3.9/dist-packages/cairo-lang
                           - /usr/local/bin/starknet
                           - /usr/local/bin/starknet-compile
 
@@ -151,7 +150,6 @@ aliases:
                 - /opt/circleci/.pyenv/shims/starknet-devnet
                 - /usr/local/bin/starknet-devnet
                 - /usr/local/lib/python3.8/site-packages
-                - /usr/local/lib/python3.9/site-packages
 
 ######################################################################################################################################################################
 # Commands

--- a/scripts/ensure-python.sh
+++ b/scripts/ensure-python.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+PY_VERSION=3.8.9
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    which "/opt/circleci/.pyenv/versions/$PY_VERSION/bin/python" || pyenv install "$PY_VERSION"
+    pyenv global "$PY_VERSION"
+fi

--- a/scripts/ensure-python.sh
+++ b/scripts/ensure-python.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Ensures that pyenv uses the desired Python version (on Linux).
+
 set -e
 
 PY_VERSION=3.8.9

--- a/scripts/install-devnet.sh
+++ b/scripts/install-devnet.sh
@@ -11,10 +11,10 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poet
 
 git clone -b master --single-branch git@github.com:Shard-Labs/starknet-devnet.git
 
-# source "$HOME/.poetry/env"
+source "$HOME/.poetry/env"
 
 cd starknet-devnet 
-poetry env use "$(which python)"
+poetry env use "$(which python3)"
 poetry build
 pip3 install dist/starknet_devnet-*-py3-none-any.whl
 cd ..

--- a/scripts/install-devnet.sh
+++ b/scripts/install-devnet.sh
@@ -2,13 +2,19 @@
 
 set -e
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - --version 1.1.12
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    which /opt/circleci/.pyenv/versions/3.8.9/bin/python3.8 || pyenv install 3.8.9
+    pyenv global 3.8.9
+fi
+
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - --version 1.1.12
 
 git clone -b master --single-branch git@github.com:Shard-Labs/starknet-devnet.git
 
 source "$HOME/.poetry/env"
 
 cd starknet-devnet 
+poetry env use "$(which python)"
 poetry build
 pip3 install dist/starknet_devnet-*-py3-none-any.whl
 cd ..

--- a/scripts/install-devnet.sh
+++ b/scripts/install-devnet.sh
@@ -11,7 +11,7 @@ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poet
 
 git clone -b master --single-branch git@github.com:Shard-Labs/starknet-devnet.git
 
-source "$HOME/.poetry/env"
+# source "$HOME/.poetry/env"
 
 cd starknet-devnet 
 poetry env use "$(which python)"

--- a/scripts/install-devnet.sh
+++ b/scripts/install-devnet.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    which /opt/circleci/.pyenv/versions/3.8.9/bin/python3.8 || pyenv install 3.8.9
-    pyenv global 3.8.9
-fi
-
 curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 - --version 1.1.12
 
 git clone -b master --single-branch git@github.com:Shard-Labs/starknet-devnet.git

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,8 @@ set -e
 
 CONFIG_FILE_NAME="hardhat.config.ts"
 
+./scripts/ensure-python.sh
+
 # setup example repo
 rm -rf starknet-hardhat-example
 git clone -b plugin --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
@@ -66,7 +68,7 @@ if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$OSTYPE" == "linux-gnu"* ]]; then
 fi
 
 # install, build and run devnet
-export PATH="$PATH:/opt/circleci/.pyenv/shims:/usr/local/bin"
+# export PATH="$PATH:/opt/circleci/.pyenv/shims:/usr/local/bin"
 which starknet-devnet || ../scripts/install-devnet.sh
 echo "starknet-devnet at: $(which starknet-devnet)"
 starknet-devnet & # assuming the default (localhost:5000)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -68,7 +68,6 @@ if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$OSTYPE" == "linux-gnu"* ]]; then
 fi
 
 # install, build and run devnet
-# export PATH="$PATH:/opt/circleci/.pyenv/shims:/usr/local/bin"
 which starknet-devnet || ../scripts/install-devnet.sh
 echo "starknet-devnet at: $(which starknet-devnet)"
 starknet-devnet & # assuming the default (localhost:5000)


### PR DESCRIPTION
## Usage related changes
None

## Development related changes
- In CircleCI, Use Python 3.8.9 with pyenv (previously used the default Python3 (3.9))

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [ ] I have documented the changes
- [ ] I have updated the tests
- [ ] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
