### PR TITLE
Invoke options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If no paths are provided, all Starknet contracts in the default contracts direct
 
 `--cairo-path` allows specifying the locations of imported files, if necessary. Separate them with a colon (:), e.g. `--cairo-path='path/to/lib1:path/to/lib2'`
 
-`--account-contract` allows compiling a contract containing account implementation.
+`--account-contract` allows compiling an account contract.
 
 ### `starknet-deploy`
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ This plugin defines the following Hardhat commands (also called tasks):
 ### `starknet-compile`
 
 ```
-npx hardhat starknet-compile [PATH...] [--cairo-path "<LIB_PATH1>:<LIB_PATH2>:..."]
+npx hardhat starknet-compile [PATH...] [--cairo-path "<LIB_PATH1>:<LIB_PATH2>:..."] [--account-contract]
 ```
 
 If no paths are provided, all Starknet contracts in the default contracts directory are compiled. Paths can be files and directories.
 
 `--cairo-path` allows specifying the locations of imported files, if necessary. Separate them with a colon (:), e.g. `--cairo-path='path/to/lib1:path/to/lib2'`
+
+`--account-contract` allows compiling a contract containing account implementation.
 
 ### `starknet-deploy`
 

--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -1,4 +1,4 @@
-import { StarknetContract, StringMap } from "./types";
+import { Numeric, StarknetContract, StringMap } from "./types";
 import { Call, hash, RawCalldata } from "starknet";
 import { BigNumberish, toBN } from "starknet/utils/number";
 import * as ellipticCurve from "starknet/utils/ellipticCurve";
@@ -69,8 +69,8 @@ export function signMultiCall(
 export function handleMultiCall(
     accountAddress: string,
     callParameters: CallParameters[],
-    nonce: string,
-    maxFee: string
+    nonce: Numeric,
+    maxFee: Numeric
 ) {
     // Transform a CallParameters array into Call array, so it can be used by the hash functions
     const callArray: Call[] = callParameters.map((callParameters) => {
@@ -98,12 +98,14 @@ export function handleMultiCall(
         rawCalldata = rawCalldata.concat(call.calldata);
     });
 
-    const messageHash = hash.hashMulticall(accountAddress, callArray, nonce, maxFee);
+    const adaptedNonce = nonce.toString();
+    const adaptedMaxFee = "0x" + maxFee.toString(16);
+    const messageHash = hash.hashMulticall(accountAddress, callArray, adaptedNonce, adaptedMaxFee);
 
     const args = {
         call_array: executeCallArray,
         calldata: rawCalldata,
-        nonce: nonce
+        nonce: adaptedNonce
     };
 
     return { messageHash, args };

--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -53,7 +53,7 @@ export function signMultiCall(
     messageHash: string
 ): bigint[] {
     if (publicKey === "0x0") {
-        return [0n, 0n];
+        return [BigInt(0), BigInt(0)];
     }
     return ellipticCurve.sign(keyPair, BigInt(messageHash).toString(16)).map(BigInt);
 }

--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -69,7 +69,8 @@ export function signMultiCall(
 export function handleMultiCall(
     accountAddress: string,
     callParameters: CallParameters[],
-    nonce: string
+    nonce: string,
+    maxFee: string
 ) {
     // Transform a CallParameters array into Call array, so it can be used by the hash functions
     const callArray: Call[] = callParameters.map((callParameters) => {
@@ -97,7 +98,7 @@ export function handleMultiCall(
         rawCalldata = rawCalldata.concat(call.calldata);
     });
 
-    const messageHash = hash.hashMulticall(accountAddress, callArray, nonce, "0");
+    const messageHash = hash.hashMulticall(accountAddress, callArray, nonce, maxFee);
 
     const args = {
         call_array: executeCallArray,

--- a/src/account.ts
+++ b/src/account.ts
@@ -141,7 +141,7 @@ export abstract class Account {
         return await this.multiInteract(InteractChoice.ESTIMATE_FEE, callParameters, options);
     }
 
-    async multiInteract(
+    private async multiInteract(
         choice: InteractChoice,
         callParameters: CallParameters[],
         options: InteractOptions = {}

--- a/src/account.ts
+++ b/src/account.ts
@@ -110,10 +110,7 @@ export abstract class Account {
      * @param callParameters an array with the paramaters for each call
      * @returns an array with each call's repsecting response object
      */
-    async multiCall(
-        callParameters: CallParameters[],
-        options?: CallOptions
-    ): Promise<StringMap[]> {
+    async multiCall(callParameters: CallParameters[], options?: CallOptions): Promise<StringMap[]> {
         const { response } = <{ response: string[] }>(
             await this.multiInteract(InteractChoice.CALL, callParameters, options)
         );
@@ -126,10 +123,7 @@ export abstract class Account {
      * @param callParameters an array with the paramaters for each invoke
      * @returns the transaction hash of the invoke
      */
-    async multiInvoke(
-        callParameters: CallParameters[],
-        options?: InvokeOptions
-    ): Promise<string> {
+    async multiInvoke(callParameters: CallParameters[], options?: InvokeOptions): Promise<string> {
         // Invoke only returns one transaction hash, as the multiple invokes are done by the account contract, but only one is sent to it.
         return await this.multiInteract(InteractChoice.INVOKE, callParameters, options);
     }
@@ -152,11 +146,14 @@ export abstract class Account {
         options: InteractOptions = {}
     ) {
         const nonce = options?.nonce?.toString() || (await this.getNonce());
+        const maxFee = "0x" + (options?.maxFee?.toString(16) || "0");
 
+        console.log("DEBUG nonce maxfee options", nonce, maxFee, options);
         const { messageHash, args } = handleMultiCall(
             this.starknetContract.address,
             callParameters,
-            nonce
+            nonce,
+            maxFee
         );
 
         const signatures = this.getSignatures(messageHash);

--- a/src/account.ts
+++ b/src/account.ts
@@ -148,7 +148,6 @@ export abstract class Account {
         const nonce = options?.nonce?.toString() || (await this.getNonce());
         const maxFee = "0x" + (options?.maxFee?.toString(16) || "0");
 
-        console.log("DEBUG nonce maxfee options", nonce, maxFee, options);
         const { messageHash, args } = handleMultiCall(
             this.starknetContract.address,
             callParameters,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,8 @@ export const ALPHA_MAINNET_INTERNALLY = "alphaMainnet";
 export const DEFAULT_STARKNET_NETWORK = ALPHA_TESTNET_INTERNALLY;
 export const ALPHA_URL = "https://alpha4.starknet.io";
 export const ALPHA_MAINNET_URL = "https://alpha-mainnet.starknet.io";
+export const TESTNET_CHAIN_ID = "SN_GOERLI";
+export const ALPHA_MAINNET_CHAIN_ID = "SN_MAIN";
 
 export const CHECK_STATUS_TIMEOUT = 5000; // ms
 export const CHECK_STATUS_RECOVER_TIMEOUT = 10000; // ms

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -2,7 +2,7 @@ import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import * as path from "path";
 
-import { ABI_SUFFIX, PLUGIN_NAME, SHORT_STRING_MAX_CHARACTERS } from "./constants";
+import { ABI_SUFFIX, PLUGIN_NAME, SHORT_STRING_MAX_CHARACTERS, TESTNET_CHAIN_ID } from "./constants";
 import { AccountImplementationType, StarknetContractFactory } from "./types";
 import { Account, ArgentAccount, OpenZeppelinAccount } from "./account";
 import { checkArtifactExists, findPath, getAccountPath } from "./utils";
@@ -38,6 +38,7 @@ export async function getContractFactoryUtil(hre: HardhatRuntimeEnvironment, con
         metadataPath,
         abiPath,
         networkID: hre.config.starknet.network,
+        chainID: hre.config.starknet.networkConfig.chainID || TESTNET_CHAIN_ID,
         gatewayUrl: hre.config.starknet.networkUrl,
         feederGatewayUrl: hre.config.starknet.networkUrl
     });

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -2,7 +2,12 @@ import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import * as path from "path";
 
-import { ABI_SUFFIX, PLUGIN_NAME, SHORT_STRING_MAX_CHARACTERS, TESTNET_CHAIN_ID } from "./constants";
+import {
+    ABI_SUFFIX,
+    PLUGIN_NAME,
+    SHORT_STRING_MAX_CHARACTERS,
+    TESTNET_CHAIN_ID
+} from "./constants";
 import { AccountImplementationType, StarknetContractFactory } from "./types";
 import { Account, ArgentAccount, OpenZeppelinAccount } from "./account";
 import { checkArtifactExists, findPath, getAccountPath } from "./utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ task("starknet-compile", "Compiles Starknet contracts")
         "Allows specifying the locations of imported files, if necessary.\n" +
             "Separate them with a colon (:), e.g. --cairo-path='path/to/lib1:path/to/lib2'"
     )
-    .addFlag("accountContract", "Use this flag if you are compiling an account contract")
+    .addFlag("accountContract", "Allows compiling an account contract.")
     .setAction(starknetCompileAction);
 
 task("starknet-deploy", "Deploys Starknet contracts which have been compiled.")

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,9 @@ import {
     ALPHA_MAINNET_URL,
     VOYAGER_GOERLI_CONTRACT_API_URL,
     VOYAGER_MAINNET_CONTRACT_API_URL,
-    DEFAULT_STARKNET_NETWORK
+    DEFAULT_STARKNET_NETWORK,
+    TESTNET_CHAIN_ID,
+    ALPHA_MAINNET_CHAIN_ID
 } from "./constants";
 import { HardhatConfig, HardhatUserConfig } from "hardhat/types";
 import { getDefaultHttpNetworkConfig, getNetwork } from "./utils";
@@ -92,14 +94,16 @@ extendConfig((config: HardhatConfig) => {
     if (!config.networks.alpha) {
         config.networks.alpha = getDefaultHttpNetworkConfig(
             ALPHA_URL,
-            VOYAGER_GOERLI_CONTRACT_API_URL
+            VOYAGER_GOERLI_CONTRACT_API_URL,
+            TESTNET_CHAIN_ID
         );
     }
 
     if (!config.networks.alphaMainnet) {
         config.networks.alphaMainnet = getDefaultHttpNetworkConfig(
             ALPHA_MAINNET_URL,
-            VOYAGER_MAINNET_CONTRACT_API_URL
+            VOYAGER_MAINNET_CONTRACT_API_URL,
+            ALPHA_MAINNET_CHAIN_ID
         );
     }
 });
@@ -117,6 +121,7 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
         "starknet.network in hardhat.config"
     );
     config.starknet.networkUrl = networkConfig.url;
+    config.starknet.networkConfig = networkConfig;
 });
 
 // add venv wrapper or docker wrapper of starknet

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ task("starknet-deploy", "Deploys Starknet contracts which have been compiled.")
     .addOptionalParam(
         "inputs",
         "Space separated values forming constructor input.\n" +
-            `Pass them as a single string; e.g. --inputs "${"1 2 3"}"\n` +
+            "Pass them as a single string; e.g. --inputs '1 2 3'\n" +
             "You would typically use this feature when deploying a single contract.\n" +
             "If you're deploying multiple contracts, they'll all use the same input."
     )
@@ -243,13 +243,14 @@ task("starknet-invoke", "Invokes a function on a contract in the provided addres
     .addOptionalParam(
         "inputs",
         "Space separated values forming function input.\n" +
-            `Pass them as a single string; e.g. --inputs "${"1 2 3"}"`
+            "Pass them as a single string; e.g. --inputs '1 2 3'"
     )
     .addOptionalParam("signature", "The call signature")
     .addOptionalParam(
         "wallet",
         "The wallet to use, defined in the 'hardhat.config' file. If omitted, the '--no_wallet' flag will be passed when invoking."
     )
+    .addOptionalParam("maxFee", "Maximum gas fee which you will tolerate.")
     .setAction(starknetInvokeAction);
 
 task("starknet-call", "Invokes a function on a contract in the provided address.")
@@ -261,7 +262,7 @@ task("starknet-call", "Invokes a function on a contract in the provided address.
     .addOptionalParam(
         "inputs",
         "Space separated values forming function input.\n" +
-            `Pass them as a single string; e.g. --inputs "${"1 2 3"}"`
+            "Pass them as a single string; e.g. --inputs '1 2 3'"
     )
     .addOptionalParam("signature", "The call signature")
     .addOptionalParam(
@@ -272,6 +273,8 @@ task("starknet-call", "Invokes a function on a contract in the provided address.
         "blockNumber",
         "The number of the block to call. If omitted, the pending block will be queried."
     )
+    .addOptionalParam("nonce", "The nonce to provide to your account")
+    .addOptionalParam("maxFee", "Maximum gas fee which you will tolerate.")
     .setAction(starknetCallAction);
 
 task("starknet-estimate-fee", "Estimates the gas fee of a function execution.")
@@ -283,7 +286,7 @@ task("starknet-estimate-fee", "Estimates the gas fee of a function execution.")
     .addOptionalParam(
         "inputs",
         "Space separated values forming function input.\n" +
-            `Pass them as a single string; e.g. --inputs "${"1 2 3"}"`
+            "Pass them as a single string; e.g. --inputs '1 2 3'"
     )
     .addOptionalParam("signature", "The call signature")
     .addOptionalParam(
@@ -294,6 +297,7 @@ task("starknet-estimate-fee", "Estimates the gas fee of a function execution.")
         "blockNumber",
         "The number of the block to call. If omitted, the pending block will be queried."
     )
+    .addOptionalParam("nonce", "The nonce to provide to your account")
     .setAction(starknetEstimateFeeAction);
 
 task("starknet-deploy-account", "Deploys a new account according to the parameters.")

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,10 +153,7 @@ task("starknet-compile", "Compiles Starknet contracts")
         "Allows specifying the locations of imported files, if necessary.\n" +
             "Separate them with a colon (:), e.g. --cairo-path='path/to/lib1:path/to/lib2'"
     )
-    .addFlag(
-        "accountContract",
-        "Use this flag if you are compiling an account contract"
-    )
+    .addFlag("accountContract", "Use this flag if you are compiling an account contract")
     .setAction(starknetCompileAction);
 
 task("starknet-deploy", "Deploys Starknet contracts which have been compiled.")

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,10 @@ task("starknet-compile", "Compiles Starknet contracts")
         "Allows specifying the locations of imported files, if necessary.\n" +
             "Separate them with a colon (:), e.g. --cairo-path='path/to/lib1:path/to/lib2'"
     )
+    .addFlag(
+        "accountContract",
+        "Use this flag if you are compiling an account contract"
+    )
     .setAction(starknetCompileAction);
 
 task("starknet-deploy", "Deploys Starknet contracts which have been compiled.")

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -12,6 +12,7 @@ interface CompileWrapperOptions {
     output: string;
     abi: string;
     cairoPath: string;
+    accountContract: boolean;
 }
 
 interface DeployWrapperOptions {
@@ -57,7 +58,7 @@ interface DeployAccountWrapperOptions {
 
 export abstract class StarknetWrapper {
     protected prepareCompileOptions(options: CompileWrapperOptions): string[] {
-        return [
+        const ret = [
             options.file,
             "--abi",
             options.abi,
@@ -66,6 +67,12 @@ export abstract class StarknetWrapper {
             "--cairo_path",
             options.cairoPath
         ];
+
+        if (options.accountContract) {
+            ret.push("--account_contract");
+        }
+
+        return ret;
     }
 
     public abstract compile(options: CompileWrapperOptions): Promise<ProcessResult>;

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -140,7 +140,7 @@ export abstract class StarknetWrapper {
             prepared.push("--no_wallet");
         }
 
-        if (options.maxFee) {
+        if (options.choice.allowsMaxFee && options.maxFee) {
             prepared.push("--max_fee", options.maxFee);
         }
 

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -34,6 +34,7 @@ interface InteractWrapperOptions {
     account?: string;
     accountDir?: string;
     networkID?: string;
+    chainID?: string;
     gatewayUrl: string;
     feederGatewayUrl: string;
     blockNumber?: string;
@@ -120,6 +121,7 @@ export abstract class StarknetWrapper {
         if (options.wallet) {
             prepared.push("--wallet", options.wallet);
             prepared.push("--network_id", options.networkID);
+            prepared.push("--chain_id", options.chainID);
 
             if (options.account) {
                 prepared.push("--account", options.account);

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -22,6 +22,8 @@ interface DeployWrapperOptions {
 }
 
 interface InteractWrapperOptions {
+    maxFee: string;
+    nonce: string;
     choice: InteractChoice;
     address: string;
     abi: string;
@@ -127,6 +129,14 @@ export abstract class StarknetWrapper {
             }
         } else {
             prepared.push("--no_wallet");
+        }
+
+        if (options.maxFee) {
+            prepared.push("--max_fee", options.maxFee);
+        }
+
+        if (options.nonce) {
+            prepared.push("--nonce", options.nonce);
         }
 
         return prepared;

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -155,7 +155,8 @@ export async function starknetCompileAction(args: TaskArguments, hre: HardhatRun
                 file,
                 output: outputPath,
                 abi: abiPath,
-                cairoPath
+                cairoPath,
+                accountContract: args.accountContract
             });
 
             statusCode += processExecuted(executed, true);

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -502,6 +502,7 @@ function setRuntimeNetwork(args: TaskArguments, hre: HardhatRuntimeEnvironment) 
     }
     hre.config.starknet.network = hre.starknet.network = networkName;
     hre.config.starknet.networkUrl = hre.starknet.networkUrl = networkConfig.url;
+    hre.config.starknet.networkConfig = networkConfig;
     console.log(`Using network ${hre.starknet.network} at ${hre.starknet.networkUrl}`);
 }
 

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -411,7 +411,9 @@ async function starknetInteractAction(
         gatewayUrl: gatewayUrl,
         feederGatewayUrl: gatewayUrl,
         blockNumber: args.blockNumber ? args.blockNumber : undefined,
-        networkID: wallet ? args.starknetNetwork : undefined
+        networkID: wallet ? args.starknetNetwork : undefined,
+        maxFee: args.maxFee ? args.maxFee : undefined,
+        nonce: args.nonce ? args.nonce : undefined
     });
 
     const statusCode = processExecuted(executed, true);

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -10,6 +10,7 @@ import { StarknetWrapper } from "./starknet-wrappers";
 import { FlushResponse, LoadL1MessagingContractResponse } from "./devnet-utils";
 import { Account, ArgentAccount, OpenZeppelinAccount } from "./account";
 import { Transaction, TransactionReceipt } from "./starknet-types";
+import { HttpNetworkConfig } from "hardhat/types/config";
 
 type StarknetConfig = {
     dockerizedVersion?: string;
@@ -17,6 +18,7 @@ type StarknetConfig = {
     wallets?: WalletUserConfig;
     network?: string;
     networkUrl?: string;
+    networkConfig?: HttpNetworkConfig;
 };
 
 type WalletUserConfig = {
@@ -57,6 +59,7 @@ declare module "hardhat/types/config" {
 
     export interface HttpNetworkConfig {
         verificationUrl?: string;
+        chainID?: string;
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import {
     PENDING_BLOCK_NUMBER,
     CHECK_STATUS_RECOVER_TIMEOUT
 } from "./constants";
-import { adaptLog } from "./utils";
+import { adaptLog, copyWithBigint } from "./utils";
 import { adaptInputUtil, adaptOutputUtil } from "./adapt";
 import { StarknetWrapper } from "./starknet-wrappers";
 import { Wallet } from "hardhat/types";
@@ -77,11 +77,11 @@ export interface StringMap {
  * Enumerates the ways of interacting with a contract.
  */
 export class InteractChoice {
-    static readonly INVOKE = new InteractChoice("invoke", "invoke");
+    static readonly INVOKE = new InteractChoice("invoke", "invoke", true);
 
-    static readonly CALL = new InteractChoice("call", "call");
+    static readonly CALL = new InteractChoice("call", "call", true);
 
-    static readonly ESTIMATE_FEE = new InteractChoice("estimate_fee", "estimateFee");
+    static readonly ESTIMATE_FEE = new InteractChoice("estimate_fee", "estimateFee", false);
 
     private constructor(
         /**
@@ -91,7 +91,12 @@ export class InteractChoice {
         /**
          * The way it's supposed to be used internally in code.
          */
-        public readonly internalCommand: keyof StarknetContract
+        public readonly internalCommand: keyof StarknetContract,
+
+        /**
+         * Indicates whether the belonging CLI option allows specifying max_fee.
+         */
+        public readonly allowsMaxFee: boolean
     ) {}
 }
 
@@ -424,6 +429,7 @@ export class StarknetContract {
         this.abiPath = config.abiPath;
         this.abi = readAbi(this.abiPath);
         this.networkID = config.networkID;
+        this.chainID = config.chainID;
         this.gatewayUrl = config.gatewayUrl;
         this.feederGatewayUrl = config.feederGatewayUrl;
     }
@@ -463,8 +469,8 @@ export class StarknetContract {
             gatewayUrl: this.gatewayUrl,
             feederGatewayUrl: this.feederGatewayUrl,
             blockNumber: "blockNumber" in options ? options.blockNumber : undefined,
-            maxFee: options.maxFee ? options.maxFee.toString() : undefined,
-            nonce: options.nonce ? options.maxFee.toString() : undefined
+            maxFee: options.maxFee?.toString() || "0",
+            nonce: options.nonce?.toString()
         });
 
         if (executed.statusCode) {
@@ -538,17 +544,13 @@ export class StarknetContract {
         args?: StringMap,
         options: CallOptions = {}
     ): Promise<StringMap> {
-        const optionsCopy: CallOptions = JSON.parse(
-            JSON.stringify(options, (_key, value) =>
-                typeof value === "bigint" ? value.toString() : value
-            )
-        ); // copy because of potential changes to the object
+        options = copyWithBigint(options); // copy because of potential changes to the object
 
-        if (optionsCopy.blockNumber === undefined) {
+        if (options.blockNumber === undefined) {
             // using || operator would not handle the zero case correctly
-            optionsCopy.blockNumber = PENDING_BLOCK_NUMBER;
+            options.blockNumber = PENDING_BLOCK_NUMBER;
         }
-        const executed = await this.interact(InteractChoice.CALL, functionName, args, optionsCopy);
+        const executed = await this.interact(InteractChoice.CALL, functionName, args, options);
         return this.adaptOutput(functionName, executed.stdout.toString());
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface StarknetContractConfig {
     starknetWrapper: StarknetWrapper;
     abiPath: string;
     networkID: string;
+    chainID: string;
     gatewayUrl: string;
     feederGatewayUrl: string;
 }
@@ -273,6 +274,7 @@ export class StarknetContractFactory {
     private constructorAbi: starknet.CairoFunction;
     private metadataPath: string;
     private networkID: string;
+    private chainID: string;
     private gatewayUrl: string;
     private feederGatewayUrl: string;
 
@@ -281,6 +283,7 @@ export class StarknetContractFactory {
         this.abiPath = config.abiPath;
         this.abi = readAbi(this.abiPath);
         this.networkID = config.networkID;
+        this.chainID = config.chainID;
         this.gatewayUrl = config.gatewayUrl;
         this.feederGatewayUrl = config.feederGatewayUrl;
         this.metadataPath = config.metadataPath;
@@ -342,6 +345,7 @@ export class StarknetContractFactory {
             abiPath: this.abiPath,
             starknetWrapper: this.starknetWrapper,
             networkID: this.networkID,
+            chainID: this.chainID,
             feederGatewayUrl: this.feederGatewayUrl,
             gatewayUrl: this.gatewayUrl
         });
@@ -391,6 +395,7 @@ export class StarknetContractFactory {
             abiPath: this.abiPath,
             starknetWrapper: this.starknetWrapper,
             networkID: this.networkID,
+            chainID: this.chainID,
             feederGatewayUrl: this.feederGatewayUrl,
             gatewayUrl: this.gatewayUrl
         });
@@ -408,6 +413,7 @@ export class StarknetContract {
     private abi: starknet.Abi;
     private abiPath: string;
     private networkID: string;
+    private chainID: string;
     private gatewayUrl: string;
     private feederGatewayUrl: string;
     private _address: string;
@@ -453,6 +459,7 @@ export class StarknetContract {
             account: options.wallet?.accountName,
             accountDir: options.wallet?.accountPath,
             networkID: this.networkID,
+            chainID: this.chainID,
             gatewayUrl: this.gatewayUrl,
             feederGatewayUrl: this.feederGatewayUrl,
             blockNumber: "blockNumber" in options ? options.blockNumber : undefined,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,3 +179,11 @@ export function flattenStringMap(stringMap: StringMap): string[] {
     });
     return result;
 }
+
+export function copyWithBigint(object: unknown): unknown {
+    return JSON.parse(
+        JSON.stringify(object, (_key, value) =>
+            typeof value === "bigint" ? value.toString() : value
+        )
+    );
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,10 @@ const globPromise = promisify(glob);
  * @returns the log message with adaptation replacements
  */
 export function adaptLog(msg: string): string {
-    return msg.replace("--network", "--starknet-network").replace("gateway_url", "gateway-url");
+    return msg
+        .replace("--network", "--starknet-network")
+        .replace("gateway_url", "gateway-url")
+        .replace("--account_contract", "--account-contract");
 }
 
 const DOCKER_HOST = "host.docker.internal";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,11 +52,13 @@ export function adaptUrl(url: string): string {
 
 export function getDefaultHttpNetworkConfig(
     url: string,
-    verificationUrl: string
+    verificationUrl: string,
+    chainID: string
 ): HttpNetworkConfig {
     return {
         url,
-        verificationUrl: verificationUrl,
+        verificationUrl,
+        chainID,
         accounts: undefined,
         gas: undefined,
         gasMultiplier: undefined,

--- a/test/configuration-tests/with-compilation-options/check.sh
+++ b/test/configuration-tests/with-compilation-options/check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+PREFIX=$(dirname "$0")
+
+echo "Testing rejection of compilation without the account flag"
+npx hardhat starknet-compile contracts/contract_with_execute.cairo 2>&1 \
+    | tail -n +2 \
+    | diff - "$PREFIX/without-account-flag.txt"
+echo "Success"
+
+npx hardhat starknet-compile contracts/contract_with_execute.cairo --acount-contract

--- a/test/configuration-tests/with-compilation-options/check.sh
+++ b/test/configuration-tests/with-compilation-options/check.sh
@@ -3,10 +3,15 @@ set -e
 
 PREFIX=$(dirname "$0")
 
+CONTRACT_NAME=contract_with_execute.cairo
+
+cp "$PREFIX/$CONTRACT_NAME" contracts/
+
 echo "Testing rejection of compilation without the account flag"
-npx hardhat starknet-compile contracts/contract_with_execute.cairo 2>&1 \
-    | tail -n +2 \
+npx hardhat starknet-compile "contracts/$CONTRACT_NAME" 2>&1 \
+    | tail -n +3 \
+    | head -n 1 \
     | diff - "$PREFIX/without-account-flag.txt"
 echo "Success"
 
-npx hardhat starknet-compile contracts/contract_with_execute.cairo --acount-contract
+npx hardhat starknet-compile "contracts/$CONTRACT_NAME" --acount-contract

--- a/test/configuration-tests/with-compilation-options/check.sh
+++ b/test/configuration-tests/with-compilation-options/check.sh
@@ -14,4 +14,4 @@ npx hardhat starknet-compile "contracts/$CONTRACT_NAME" 2>&1 \
     | diff - "$PREFIX/without-account-flag.txt"
 echo "Success"
 
-npx hardhat starknet-compile "contracts/$CONTRACT_NAME" --acount-contract
+npx hardhat starknet-compile "contracts/$CONTRACT_NAME" --account-contract

--- a/test/configuration-tests/with-compilation-options/contract_with_execute.cairo
+++ b/test/configuration-tests/with-compilation-options/contract_with_execute.cairo
@@ -1,0 +1,5 @@
+%lang starknet
+@external
+func __execute__():
+    return ()
+end

--- a/test/configuration-tests/with-compilation-options/hardhat.config.ts
+++ b/test/configuration-tests/with-compilation-options/hardhat.config.ts
@@ -1,0 +1,1 @@
+import "../dist/index.js";

--- a/test/configuration-tests/with-compilation-options/hardhat.config.ts
+++ b/test/configuration-tests/with-compilation-options/hardhat.config.ts
@@ -1,1 +1,12 @@
 import "../dist/index.js";
+
+module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
+    networks: {
+        devnet: {
+            url: "http://localhost:5000"
+        }
+    }
+};

--- a/test/configuration-tests/with-compilation-options/without-account-flag.txt
+++ b/test/configuration-tests/with-compilation-options/without-account-flag.txt
@@ -1,5 +1,1 @@
 Only account contracts may have a function named "__execute__". Use --account-contract flag.
-
-        Failed
-
-Error in plugin Starknet: Failed compilation of 1 contract.

--- a/test/configuration-tests/with-compilation-options/without-account-flag.txt
+++ b/test/configuration-tests/with-compilation-options/without-account-flag.txt
@@ -1,0 +1,5 @@
+Only account contracts may have a function named "__execute__". Use --account-contract flag.
+
+        Failed
+
+Error in plugin Starknet: Failed compilation of 1 contract.

--- a/test/general-tests/wallet-test/network.json
+++ b/test/general-tests/wallet-test/network.json
@@ -1,4 +1,5 @@
 {
     "$schema": "../../network.schema",
-    "alpha": true
+    "alpha": true,
+    "devnet": true
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "allowJs": true,
-        "target": "es2020",
+        "target": "es2016",
         "sourceMap": true,
         "esModuleInterop": true,
         "strict": true,


### PR DESCRIPTION
## Usage related changes
- Allow specifying maxFee and nonce.
- Introduce `--account-contract` flag for compiling account contracts.
  - Account contracts are currently those with a function called `__execute__`, hence the addition of such a test. Couldn't make it 

## Development related changes
- Enable wallet testing on devnet.
- Revert to es2016 in tsconfig.json (es2020 was never a part of an official plugin release, but happened in a commit between the latest release and this commit).
- Introduce `copyWithBigint` which basically takes an already existing functionality and wraps it into a function. The function is now used in one more place.
- Make Account methods protected.
- Unfortunately some hackiness is introduced in multiInteract in account.ts, if the reviewer should find a better way of dealing with it
- Refactor InteractChoice making it a class with methods and properties - pushes some logic directly into InteractChoice instead of having to write ifs and elses in various places.

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
