### PR TITLE
Add assert-contains.py script

### DIFF
--- a/scripts/assert-contains.py
+++ b/scripts/assert-contains.py
@@ -1,0 +1,22 @@
+#!/bin/python3
+
+"""
+Asserts that stdin contains the <PATTERN> provided as CLI argument.
+"""
+
+import sys
+
+if len(sys.argv) != 2:
+    sys.exit(sys.argv[0] + " <PATTERN>")
+
+pattern = sys.argv[1]
+input_content = sys.stdin.read()
+
+if pattern in input_content:
+    sys.exit(0)
+
+print("Pattern not in input", file=sys.stderr)
+print("Pattern:", pattern, file=sys.stderr)
+print("Input:", input_content, file=sys.stderr)
+
+sys.exit(1)

--- a/test/configuration-tests/with-compilation-options/check.sh
+++ b/test/configuration-tests/with-compilation-options/check.sh
@@ -7,11 +7,11 @@ CONTRACT_NAME=contract_with_execute.cairo
 
 cp "$PREFIX/$CONTRACT_NAME" contracts/
 
+EXPECTED='Only account contracts may have a function named "__execute__". Use --account-contract flag.'
+
 echo "Testing rejection of compilation without the account flag"
 npx hardhat starknet-compile "contracts/$CONTRACT_NAME" 2>&1 \
-    | tail -n +3 \
-    | head -n 1 \
-    | diff - "$PREFIX/without-account-flag.txt"
+    | ../scripts/assert-contains.py "$EXPECTED"
 echo "Success"
 
 npx hardhat starknet-compile "contracts/$CONTRACT_NAME" --account-contract

--- a/test/configuration-tests/with-compilation-options/without-account-flag.txt
+++ b/test/configuration-tests/with-compilation-options/without-account-flag.txt
@@ -1,1 +1,0 @@
-Only account contracts may have a function named "__execute__". Use --account-contract flag.


### PR DESCRIPTION
## Usage related changes
None

## Development related changes
- Introduce a Python script for asserting that an input stream contains a pattern.
- Remove the file holding the expected content.

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
