### PR TITLE
Fix paths in compilation-option tests

### DIFF
--- a/test/configuration-tests/with-account-compilation-option/check.sh
+++ b/test/configuration-tests/with-account-compilation-option/check.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 set -e
 
-PREFIX=$(dirname "$0")
-
 CONTRACT_NAME=contract_with_execute.cairo
+CONTRACT_PATH="contracts/$CONTRACT_NAME"
 
-cp "$PREFIX/$CONTRACT_NAME" contracts/
+cp "$(dirname "$0")/$CONTRACT_NAME" "$CONTRACT_PATH"
 
 EXPECTED='Only account contracts may have a function named "__execute__". Use --account-contract flag.'
 
 echo "Testing rejection of compilation without the account flag"
-npx hardhat starknet-compile "contracts/$CONTRACT_NAME" 2>&1 \
-    | ../scripts/assert-contains.py "$EXPECTED"
+npx hardhat starknet-compile "$CONTRACT_PATH" 2>&1 |
+    ../scripts/assert-contains.py "$EXPECTED"
 echo "Success"
 
-npx hardhat starknet-compile "contracts/$CONTRACT_NAME" --account-contract
+npx hardhat starknet-compile "$CONTRACT_PATH" --account-contract

--- a/test/configuration-tests/with-disable-hint-compilation-option/check.sh
+++ b/test/configuration-tests/with-disable-hint-compilation-option/check.sh
@@ -1,18 +1,17 @@
 #!/bin/bash
 set -e
 
-PREFIX=$(dirname "$0")
-
 CONTRACT_NAME=contract_with_unwhitelisted_hints.cairo
+CONTRACT_PATH="contracts/$CONTRACT_NAME"
 
-cp "$PREFIX/$CONTRACT_NAME" contracts/
+cp "$(dirname "$0")/$CONTRACT_NAME" "$CONTRACT_PATH"
 
 EXPECTED="Hint is not whitelisted.
 This may indicate that this library function cannot be used in StarkNet contracts."
 
 echo "Testing rejection of compilation without the --disable-hint-validation flag"
-npx hardhat starknet-compile "$CONTRACT_NAME" 2>&1 |
+npx hardhat starknet-compile "$CONTRACT_PATH" 2>&1 |
     ../scripts/assert-contains.py "$EXPECTED"
 echo "Success"
 
-npx hardhat starknet-compile "$CONTRACT_NAME" --disable-hint-validation
+npx hardhat starknet-compile "$CONTRACT_PATH" --disable-hint-validation


### PR DESCRIPTION
## Usage related changes
None

## Development related changes
- Fix of https://github.com/Shard-Labs/starknet-hardhat-plugin/pull/85
- Fix paths in compilation-option tests
- Cancelled the workflow because it had already run successfully prior to rebasing: [CircleCI link](https://app.circleci.com/pipelines/github/Shard-Labs/starknet-hardhat-plugin/810/workflows/067fc481-af83-43a6-86f4-5d1a930f474f)

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
