### PR TITLE
Introduce --token flag for whitelisted deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ If you're passing constructor arguments, pass them space separated, but as a sin
 
 If the "--wait" flag is passed, the task will wait until the transaction status of the deployment is "PENDING" before ending.
 
-The "--salt" parameter should be an hex string which, when provided, will add a salt to the contract address.
+The "--salt" parameter should be a hex string which, when provided, causes the contract to always be deployed to the same address.
+
+The "--token" parameter indicates that your deployment is whitelisted on alpha-mainnet.
 
 Notice that this plugin relies on `--starknet-network` (or `STARKNET_NETWORK` environment variable) and not on Hardhat's `--network`. So if you define
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,10 @@ task("starknet-deploy", "Deploys Starknet contracts which have been compiled.")
             "The contract deployment address is determined by the hash of contract, salt and caller.\n" +
             "If the salt is not supplied, the contract will be deployed with a random salt."
     )
+    .addOptionalParam(
+        "token",
+        "An optional token indicating that your deployment is whitelisted on mainnet"
+    )
     .addOptionalVariadicPositionalParam(
         "paths",
         "The paths to be used for deployment.\n" +

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -21,6 +21,7 @@ interface DeployWrapperOptions {
     gatewayUrl: string;
     inputs?: string[];
     salt?: string;
+    token?: string;
 }
 
 interface InteractWrapperOptions {
@@ -97,6 +98,10 @@ export abstract class StarknetWrapper {
 
         if (options.salt) {
             prepared.push("--salt", options.salt);
+        }
+
+        if (options.token) {
+            prepared.push("--token", options.token);
         }
 
         return prepared;

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -202,8 +202,9 @@ export async function starknetDeployAction(args: TaskArguments, hre: HardhatRunt
             const executed = await hre.starknetWrapper.deploy({
                 contract: file,
                 gatewayUrl,
-                inputs: args.inputs ? args.inputs.split(/\s+/) : undefined,
-                salt: args.salt ? args.salt : undefined
+                inputs: args.inputs?.split(/\s+/),
+                salt: args.salt,
+                token: args.token
             });
             if (args.wait) {
                 const execResult = processExecuted(executed, false);

--- a/src/types.ts
+++ b/src/types.ts
@@ -256,6 +256,7 @@ function defaultToPendingBlock(options: CallOptions | EstimateFeeOptions): void 
 
 export interface DeployOptions {
     salt?: string;
+    token?: string;
 }
 
 export interface InvokeOptions {
@@ -346,7 +347,8 @@ export class StarknetContractFactory {
             contract: this.metadataPath,
             inputs: this.handleConstructorArguments(constructorArguments),
             gatewayUrl: this.gatewayUrl,
-            salt: options.salt
+            salt: options.salt,
+            token: options.token
         });
         if (executed.statusCode) {
             const msg =


### PR DESCRIPTION
## Usage related changes
- Introduce `--token` flag for whitelisted deployment

## Development related changes
- Remove defaulting to `undefined` with ternary in task-actions.ts

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I haven't updated the tests because testing this would require having a whitelisted address.
- [x] I haven't created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example) because testing this would require having a whitelisted address.
