### PR TITLE
Enable normal fee estimation on Devnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,20 +344,6 @@ it("should estimate fee", async function () {
 });
 ```
 
-Currently there are incompatibilities between Devnet and Plugin so, to support fee estimation on Devnet when using accounts, you temporarily have to provide `transactionVersion`:
-
-```typescript
-it("should estimate fee on Devnet", async function () {
-    const fee = account.estimateFee(
-        contract,
-        "increase_balance",
-        { amount: 10n },
-        { transactionVersion: 0 }
-    );
-    console.log("Estimated fee:", fee.amount, fee.unit);
-});
-```
-
 ### Test - transaction information and receipt
 
 ```typescript

--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -12,7 +12,7 @@ if len(sys.argv) != 2:
 tool = sys.argv[1].strip()
 
 TOOLS_USED = {
-    "starknet-devnet": "0.1.22"
+    "starknet-devnet": "0.1.23"
 }
 
 if tool not in TOOLS_USED:

--- a/src/account.ts
+++ b/src/account.ts
@@ -151,12 +151,6 @@ export abstract class Account {
         const nonce = options.nonce || (await this.getNonce());
         delete options.nonce; // the options object is incompatible if passed on with nonce
 
-        // temporary solution to support fee estimation on Devnet
-        if ("transactionVersion" in options) {
-            choice = Object.assign({}, choice);
-            choice.transactionVersion = options.transactionVersion;
-        }
-
         const { messageHash, args } = handleMultiCall(
             this.starknetContract.address,
             callParameters,

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,10 +287,7 @@ export interface CallOptions {
     maxFee?: Numeric;
 }
 
-export interface EstimateFeeOptions extends CallOptions {
-    // Workaround for devnet version mismatch
-    transactionVersion?: Numeric;
-}
+export type EstimateFeeOptions = CallOptions;
 
 export type InteractOptions = InvokeOptions | CallOptions | EstimateFeeOptions;
 

--- a/test/general-tests/account-test/network.json
+++ b/test/general-tests/account-test/network.json
@@ -1,4 +1,5 @@
 {
     "$schema": "../../network.schema",
-    "alpha": true
+    "alpha": true,
+    "devnet": true
 }


### PR DESCRIPTION
## Usage related changes
- No need for passing `transactionVersion` as a part of fee estimation options.

## Development related changes
- Bring back account testing on devnet.
- Use starknet-devnet v0.1.23 for testing.
- Set EstimateFeeOptions to be the same as CallOptions again.

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I didn't create a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example) because I didn't need to.
