### PR TITLE
Adapt Voyager verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@nomiclabs/hardhat-docker": "^2.0.2",
                 "axios": "^0.24.0",
                 "exit-hook": "2.2.1",
+                "form-data": "^4.0.0",
                 "glob": "^7.2.0",
                 "starknet": "^3.5.1"
             },
@@ -1434,6 +1435,11 @@
                 "async": "^2.4.0"
             }
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
         "node_modules/axios": {
             "version": "0.24.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
@@ -1826,6 +1832,17 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/command-exists": {
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -2015,6 +2032,14 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/depd": {
@@ -2676,6 +2701,19 @@
                 "debug": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/fp-ts": {
@@ -3792,6 +3830,25 @@
             },
             "bin": {
                 "miller-rabin": "bin/miller-rabin"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/minimalistic-assert": {
@@ -6420,6 +6477,11 @@
                 "async": "^2.4.0"
             }
         },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
         "axios": {
             "version": "0.24.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
@@ -6732,6 +6794,14 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
         "command-exists": {
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -6881,6 +6951,11 @@
                     }
                 }
             }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "depd": {
             "version": "2.0.0",
@@ -7411,6 +7486,16 @@
             "version": "1.14.9",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
             "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+        },
+        "form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            }
         },
         "fp-ts": {
             "version": "1.19.3",
@@ -8301,6 +8386,19 @@
             "requires": {
                 "bn.js": "^4.0.0",
                 "brorand": "^1.0.1"
+            }
+        },
+        "mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "requires": {
+                "mime-db": "1.52.0"
             }
         },
         "minimalistic-assert": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "@nomiclabs/hardhat-docker": "^2.0.2",
         "axios": "^0.24.0",
         "exit-hook": "2.2.1",
+        "form-data": "^4.0.0",
         "glob": "^7.2.0",
         "starknet": "^3.5.1"
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,11 @@ export const INTEGRATED_DEVNET_INTERNALLY = "integratedDevnet";
 export const TESTNET_CHAIN_ID = "SN_GOERLI";
 export const ALPHA_MAINNET_CHAIN_ID = "SN_MAIN";
 
+export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";
+export const VOYAGER_GOERLI_VERIFIED_URL = "https://goerli.voyager.online/contract/";
+export const VOYAGER_MAINNET_CONTRACT_API_URL = "https://voyager.online/api/contract/";
+export const VOYAGER_MAINNET_VERIFIED_URL = "https://voyager.online/contract/";
+
 export const CHECK_STATUS_TIMEOUT = 5000; // ms
 export const CHECK_STATUS_RECOVER_TIMEOUT = 10000; // ms
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,8 +33,6 @@ export const CHECK_STATUS_TIMEOUT = 5000; // ms
 export const CHECK_STATUS_RECOVER_TIMEOUT = 10000; // ms
 
 export const LEN_SUFFIX = "_len";
-export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";
-export const VOYAGER_MAINNET_CONTRACT_API_URL = "https://voyager.online/api/contract/";
 
 export const SHORT_STRING_MAX_CHARACTERS = 31;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,9 @@ import {
     DEFAULT_STARKNET_NETWORK,
     INTEGRATED_DEVNET_URL,
     TESTNET_CHAIN_ID,
-    ALPHA_MAINNET_CHAIN_ID
+    ALPHA_MAINNET_CHAIN_ID,
+    VOYAGER_GOERLI_VERIFIED_URL,
+    VOYAGER_MAINNET_VERIFIED_URL
 } from "./constants";
 import { getDefaultHardhatNetworkConfig, getDefaultHttpNetworkConfig, getNetwork } from "./utils";
 import { DockerWrapper, VenvWrapper } from "./starknet-wrappers";
@@ -104,6 +106,7 @@ extendConfig((config: HardhatConfig) => {
         config.networks.alpha = getDefaultHttpNetworkConfig(
             ALPHA_URL,
             VOYAGER_GOERLI_CONTRACT_API_URL,
+            VOYAGER_GOERLI_VERIFIED_URL,
             TESTNET_CHAIN_ID
         );
     }
@@ -112,6 +115,7 @@ extendConfig((config: HardhatConfig) => {
         config.networks.alphaMainnet = getDefaultHttpNetworkConfig(
             ALPHA_MAINNET_URL,
             VOYAGER_MAINNET_CONTRACT_API_URL,
+            VOYAGER_MAINNET_VERIFIED_URL,
             ALPHA_MAINNET_CHAIN_ID
         );
     }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -64,6 +64,7 @@ declare module "hardhat/types/config" {
 
     export interface HttpNetworkConfig {
         verificationUrl?: string;
+        verifiedUrl?: string;
         starknetChainId?: string;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,11 +64,13 @@ export function adaptUrl(url: string): string {
 export function getDefaultHttpNetworkConfig(
     url: string,
     verificationUrl: string,
+    verifiedUrl: string,
     starknetChainId: string
 ): HttpNetworkConfig {
     return {
         url,
         verificationUrl,
+        verifiedUrl,
         starknetChainId,
         accounts: undefined,
         gas: undefined,

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -1,5 +1,0 @@
-
-// TODO refactor and add links to verified files
-export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";
-export const VOYAGER_MAINNET_CONTRACT_API_URL = "https://voyager.online/api/contract/";
-

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -1,0 +1,5 @@
+
+// TODO refactor and add links to verified files
+export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";
+export const VOYAGER_MAINNET_CONTRACT_API_URL = "https://voyager.online/api/contract/";
+

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -16,18 +16,13 @@ sleep 30s
 echo "Verifying contract at $address"
 npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address
 
-echo "Sleeping before curling"
+echo "Sleeping before fetching the verified code - seems to be necessary"
 sleep 10s
 
-VERIFICATION_RESP="/tmp/verification-resp.json"
-curl "https://goerli.voyager.online/api/contract/$address/code" > $VERIFICATION_RESP
-
-CONTRACT_RESP="/tmp/contract-resp.cairo"
-jq -r '.contract | ."contract.cairo" | join("\n")' $VERIFICATION_RESP > $CONTRACT_RESP
-diff -B $CONTRACT_RESP $MAIN_CONTRACT
-
-UTIL_RESP="/tmp/util-resp.cairo"
-jq -r '.contract | ."util.cairo" | join("\n")' $VERIFICATION_RESP > $UTIL_RESP
-diff -B $UTIL_RESP $UTIL_CONTRACT
-
-echo "Contracts from the response matching the original ones."
+is_verified=$(curl "https://goerli.voyager.online/api/contract/$address/code" | jq ".abiVerified")
+if [ is_verified == "true" ]; then
+    echo "Successfully verified!"
+else
+    echo "Not verified!"
+    exit 1
+fi

--- a/test/general-tests/starknet-verify/network.json
+++ b/test/general-tests/starknet-verify/network.json
@@ -1,5 +1,5 @@
 {
     "$schema": "../../network.schema",
     "alpha": true,
-    "devnet": true
+    "devnet": false
 }


### PR DESCRIPTION
## Usage related changes
- Adapt `starknet-verify` to the new Voyager API.
- Since Voyager almost always returns 502 Bad Gateway, it was hard to do some meaningful error interpretation. That's why in case of an unsuccessful verification the most likely reasons are listed.

## Development related changes
- Modify and uncomment verification testing.

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I didn't have to create a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
