### PR TITLE
Add deployment options to deployAccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ If no paths are provided, all Starknet artifacts from the default artifacts dire
 
 If you're passing constructor arguments, pass them space separated, but as a single string (due to limitations of the plugin system).
 
-If the "--wait" flag is passed, the task will wait until the transaction status of the deployment is "PENDING" before ending.
+If the `--wait` flag is passed, the task will wait until the transaction status of the deployment is one of (`PENDING`, `ACCEPTED_ON_L2`, `ACCEPTED_ON_L1`).
 
-The "--salt" parameter should be a hex string which, when provided, causes the contract to always be deployed to the same address.
+The `--salt` parameter should be a hex string which, when provided, causes the contract to always be deployed to the same address.
 
-The "--token" parameter indicates that your deployment is whitelisted on alpha-mainnet.
+The `--token` parameter indicates that your deployment is whitelisted on alpha-mainnet.
 
 Notice that this plugin relies on `--starknet-network` (or `STARKNET_NETWORK` environment variable) and not on Hardhat's `--network`. So if you define
 
@@ -162,7 +162,7 @@ Estimates the gas fee of a function execution.
 
 ### `run`
 
-No CLI options introduced, but a starknet network can be specified using the config file. See [Runtime network](#runtime-network).
+No CLI options introduced to the original `hardhat run`, but a starknet network can be specified using the config file. See [Runtime network](#runtime-network).
 
 ### `test`
 
@@ -528,26 +528,28 @@ await contract.invoke("increase_balance", { amount: 1 }, { wallet });
 ## Account
 
 An Account can be used to make proxy signed calls/transactions to other contracts.
-It's usage is exemplified [here](https://github.com/Shard-Labs/starknet-hardhat-example/blob/plugin/test/account-test.ts).
-Currently only the OpenZeppelin Account implementation is supported, and you are required to have the source files in your project.
+Its usage is exemplified [earlier in the docs](#accounts) and [in the example repo](https://github.com/Shard-Labs/starknet-hardhat-example/blob/plugin/test/oz-account-test.ts).
 
 You can choose to deploy a new Account, or use an existing one.
-
-### Supported Account Implementations
-
--   `"OpenZeppelin"`
--   `"Argent"`
 
 To deploy a new Account, use the `starknet` object's `deployAccount` method:
 
 ```typescript
-function deployAccount(accountType: AccountImplementationType);
+function deployAccount(accountType: AccountImplementationType, options?: DeployAccountOptions);
 ```
 
--   `accountType` is the implementation of the Account that you want to use.
+-   `accountType` - the implementation of the Account that you want to use; currently supported implementations:
+    - `"OpenZeppelin"`
+    - `"Argent"`
+-   `options` - optional deployment parameters:
+    -   `salt` - for fixing the account address
+    -   `privateKey` - if you don't provide one, it will be randomly generated
+    -   `token` - for indicating that the account is whitelisted on alpha-mainnet
 
+Use it like this:
 ```typescript
 const account = await starknet.deployAccount("OpenZeppelin");
+const accountWithPredefinedKey = await starknet.deployAccount("OpenZeppelin", { privateKey: process.env.MY_KEY });
 ```
 
 To retrieve an already deployed Account, use the `starknet` object's `getAccountFromAddress` method:

--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -237,8 +237,10 @@ export function parseMulticallOutput(
     return output;
 }
 
-export function generateKeys(): KeysType {
-    const starkPrivateKey = generateRandomStarkPrivateKey();
+export function generateKeys(providedKey?: string): KeysType {
+    const starkPrivateKey = providedKey
+        ? toBN(providedKey.replace(/^0x/, ""), 16)
+        : generateRandomStarkPrivateKey();
     const keyPair = ellipticCurve.getKeyPair(starkPrivateKey);
     const publicKey = ellipticCurve.getStarkKey(keyPair);
     const privateKey = "0x" + starkPrivateKey.toString(16);

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,6 +1,7 @@
 import {
     CallOptions,
     ContractInteractionFunction,
+    DeployAccountOptions,
     EstimateFeeOptions,
     FeeEstimation,
     InteractChoice,
@@ -196,17 +197,23 @@ export class OpenZeppelinAccount extends Account {
         return signMultiCall(this.publicKey, this.keyPair, messageHash);
     }
 
-    static async deployFromABI(hre: HardhatRuntimeEnvironment): Promise<OpenZeppelinAccount> {
+    static async deployFromABI(
+        hre: HardhatRuntimeEnvironment,
+        options: DeployAccountOptions = {}
+    ): Promise<OpenZeppelinAccount> {
         const contractPath = await handleAccountContractArtifacts(
             OpenZeppelinAccount.ACCOUNT_TYPE_NAME,
             OpenZeppelinAccount.ACCOUNT_ARTIFACTS_NAME,
             hre
         );
 
-        const signer = generateKeys();
+        const signer = generateKeys(options.privateKey);
 
         const contractFactory = await hre.starknet.getContractFactory(contractPath);
-        const contract = await contractFactory.deploy({ public_key: BigInt(signer.publicKey) });
+        const contract = await contractFactory.deploy(
+            { public_key: BigInt(signer.publicKey) },
+            options
+        );
 
         return new OpenZeppelinAccount(
             contract,
@@ -315,18 +322,21 @@ export class ArgentAccount extends Account {
         return await this.multiInvoke([call]);
     }
 
-    static async deployFromABI(hre: HardhatRuntimeEnvironment): Promise<ArgentAccount> {
+    static async deployFromABI(
+        hre: HardhatRuntimeEnvironment,
+        options: DeployAccountOptions = {}
+    ): Promise<ArgentAccount> {
         const contractPath = await handleAccountContractArtifacts(
             ArgentAccount.ACCOUNT_TYPE_NAME,
             ArgentAccount.ACCOUNT_ARTIFACTS_NAME,
             hre
         );
 
-        const signer = generateKeys();
+        const signer = generateKeys(options.privateKey);
         const guardian = generateKeys();
 
         const contractFactory = await hre.starknet.getContractFactory(contractPath);
-        const contract = await contractFactory.deploy();
+        const contract = await contractFactory.deploy({}, options);
 
         await contract.invoke("initialize", {
             signer: BigInt(signer.publicKey),

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -8,7 +8,12 @@ import {
     SHORT_STRING_MAX_CHARACTERS,
     TESTNET_CHAIN_ID
 } from "./constants";
-import { AccountImplementationType, BlockIdentifier, StarknetContractFactory } from "./types";
+import {
+    AccountImplementationType,
+    BlockIdentifier,
+    DeployAccountOptions,
+    StarknetContractFactory
+} from "./types";
 import { Account, ArgentAccount, OpenZeppelinAccount } from "./account";
 import { checkArtifactExists, findPath, getAccountPath } from "./utils";
 import { Transaction, TransactionReceipt } from "./starknet-types";
@@ -38,7 +43,10 @@ export async function getContractFactoryUtil(hre: HardhatRuntimeEnvironment, con
     );
     const abiPath = await findPath(artifactsPath, abiSearchTarget);
     if (!abiPath) {
-        throw new HardhatPluginError(PLUGIN_NAME, `Could not find ABI for ${contractPath}`);
+        throw new HardhatPluginError(
+            PLUGIN_NAME,
+            `Could not find ABI for contract "${contractPath}.cairo"`
+        );
     }
 
     return new StarknetContractFactory({
@@ -100,15 +108,16 @@ export function getWalletUtil(name: string, hre: HardhatRuntimeEnvironment) {
 
 export async function deployAccountUtil(
     accountType: AccountImplementationType,
-    hre: HardhatRuntimeEnvironment
+    hre: HardhatRuntimeEnvironment,
+    options?: DeployAccountOptions
 ): Promise<Account> {
     let account: Account;
     switch (accountType) {
         case "OpenZeppelin":
-            account = await OpenZeppelinAccount.deployFromABI(hre);
+            account = await OpenZeppelinAccount.deployFromABI(hre, options);
             break;
         case "Argent":
-            account = await ArgentAccount.deployFromABI(hre);
+            account = await ArgentAccount.deployFromABI(hre, options);
             break;
         default:
             throw new HardhatPluginError(PLUGIN_NAME, "Invalid account type requested.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,8 +228,8 @@ extendEnvironment((hre) => {
 
         devnet: lazyObject(() => new DevnetUtils(hre)),
 
-        deployAccount: async (accountType) => {
-            const account = await deployAccountUtil(accountType, hre);
+        deployAccount: async (accountType, options) => {
+            const account = await deployAccountUtil(accountType, hre, options);
             return account;
         },
 

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -220,8 +220,10 @@ export abstract class StarknetWrapper {
 
     public abstract getTransaction(options: TxHashQueryWrapperOptions): Promise<ProcessResult>;
 
-    protected prepareBlockQueryOptions(command: string, options: BlockQueryWrapperOptions): string[] {
-
+    protected prepareBlockQueryOptions(
+        command: string,
+        options: BlockQueryWrapperOptions
+    ): string[] {
         const commandArr = [
             command,
             "--gateway_url",

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -7,8 +7,7 @@ import {
     PLUGIN_NAME,
     ABI_SUFFIX,
     ALPHA_TESTNET,
-    DEFAULT_STARKNET_NETWORK,
-    INTEGRATED_DEVNET
+    DEFAULT_STARKNET_NETWORK
 } from "./constants";
 import { iterativelyCheckStatus, extractTxHash, InteractChoice } from "./types";
 import { ProcessResult } from "@nomiclabs/hardhat-docker";
@@ -18,7 +17,8 @@ import {
     checkArtifactExists,
     getNetwork,
     findPath,
-    getAccountPath
+    getAccountPath,
+    isStarknetDevnet
 } from "./utils";
 import {
     HardhatRuntimeEnvironment,
@@ -521,7 +521,7 @@ function setRuntimeNetwork(args: TaskArguments, hre: HardhatRuntimeEnvironment) 
 }
 
 async function runWithDevnet(hre: HardhatRuntimeEnvironment, fn: () => Promise<unknown>) {
-    if (hre.starknet.network !== INTEGRATED_DEVNET) {
+    if (!isStarknetDevnet(hre.starknet.network)) {
         await fn();
         return;
     }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -3,6 +3,7 @@ import "hardhat/types/runtime";
 import {
     AccountImplementationType,
     BlockIdentifier,
+    DeployAccountOptions,
     StarknetContract,
     StarknetContractFactory,
     StringMap
@@ -180,9 +181,13 @@ declare module "hardhat/types/runtime" {
             /**
              * Deploys an Account contract based on the ABI and the type of Account selected
              * @param accountType the enumerator value of the type of Account to use
+             * @param options optional deployment options
              * @returns an Account object
              */
-            deployAccount: (accountType: AccountImplementationType) => Promise<Account>;
+            deployAccount: (
+                accountType: AccountImplementationType,
+                options?: DeployAccountOptions
+            ) => Promise<Account>;
 
             /**
              * Returns an Account already deployed based on the address and validated by the private key

--- a/src/types.ts
+++ b/src/types.ts
@@ -272,6 +272,11 @@ export interface DeployOptions {
     token?: string;
 }
 
+export interface DeployAccountOptions extends DeployOptions {
+    /** Optional hex string. If not provided, a random value is generated. */
+    privateKey?: string;
+}
+
 export interface InvokeOptions {
     signature?: Array<Numeric>;
     wallet?: Wallet;
@@ -370,8 +375,7 @@ export class StarknetContractFactory {
             token: options.token
         });
         if (executed.statusCode) {
-            const msg =
-                "Could not deploy contract. Check the network url in config. Is it responsive?";
+            const msg = `Could not deploy contract: ${executed.stderr.toString()}`;
             throw new HardhatPluginError(PLUGIN_NAME, msg);
         }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -165,7 +165,7 @@ function isMainnet(networkName: string): boolean {
     return networkName === ALPHA_MAINNET || networkName === ALPHA_MAINNET_INTERNALLY;
 }
 
-function isStarknetDevnet(networkName: string): boolean {
+export function isStarknetDevnet(networkName: string): boolean {
     return networkName === INTEGRATED_DEVNET || networkName === INTEGRATED_DEVNET_INTERNALLY;
 }
 

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -11,18 +11,15 @@ output=$(npx hardhat starknet-deploy --starknet-network "$NETWORK" contract --in
 address=$(echo $output | sed -r "s/.*Contract address: (\w*).*/\1/")
 
 echo "Sleeping to allow Voyager to index the deployment"
-sleep 30s
+sleep 1m
 
 echo "Verifying contract at $address"
 npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address
 
-echo "Sleeping before fetching the verified code - seems to be necessary"
-sleep 30s
-
 is_verified=$(curl "https://goerli.voyager.online/api/contract/$address/code" | jq ".abiVerified")
-if [ is_verified == "true" ]; then
+if [ "$is_verified" == "true" ]; then
     echo "Successfully verified!"
 else
-    echo "Error: Not verified!"
+    echo "$0: Error: Not verified!"
     exit 1
 fi

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -17,12 +17,12 @@ echo "Verifying contract at $address"
 npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address
 
 echo "Sleeping before fetching the verified code - seems to be necessary"
-sleep 10s
+sleep 30s
 
 is_verified=$(curl "https://goerli.voyager.online/api/contract/$address/code" | jq ".abiVerified")
 if [ is_verified == "true" ]; then
     echo "Successfully verified!"
 else
-    echo "Not verified!"
+    echo "Error: Not verified!"
     exit 1
 fi


### PR DESCRIPTION
## Usage related changes
- Add deployment options to deployAccount (salt, token, privateKey).
- Stop masking error on contract deployment:
  - So far all deployment errors were masked by `Could not deploy contract. Check the network url in config. Is it responsive?`
  - Now the actual error is printed (will be somewhat messier, but more informative).

## Development related changes
- Fix formatting.
- Fix Voyager test and increase the sleep time done in it.
- Fix checking for integrated devnet

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example): https://github.com/Shard-Labs/starknet-hardhat-example/pull/57
