### PR TITLE
Devnet adaptations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ require("@shardlabs/starknet-hardhat-plugin");
 
 This plugin was tested with:
 
--   Node.js v12.22.4
--   npm/npx v7.21.1
+-   Node.js v14.17.3
+-   npm/npx v7.19.1
 -   Docker v20.10.8 (optional):
     -   Since plugin version 0.3.4, Docker is no longer necessary if you opt for a Python environment (more info in [Config](#cairo-version)).
     -   If you opt for the containerized version, make sure you have a running Docker daemon.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Notice that this plugin relies on `--starknet-network` (or `STARKNET_NETWORK` en
 module.exports = {
     networks: {
         myNetwork: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };
@@ -90,10 +90,11 @@ module.exports = {
 
 you can use it by calling `npx hardhat starknet-deploy --starknet-network myNetwork`.
 
-The Alpha networks are available by default, you don't need to define them in the config file; just pass:
+The Alpha networks and integrated Devnet are available by default, you don't need to define them in the config file; just pass:
 
 -   `--starknet-network alpha` or `--starknet-network alpha-goerli` for Alpha Testnet (on Goerli)
 -   `--starknet-network alpha-mainnet` for Alpha Mainnet
+-   `--starknet-network integrated-devnet` for integrated Devnet
 
 ```
 npx hardhat starknet-deploy starknet-artifacts/contract.cairo/ --inputs "1 2 3"
@@ -450,7 +451,7 @@ module.exports = {
   },
   networks: {
     myNetwork: {
-      url: "http://localhost:5000" // caveat: localhost on MacOS might not be bound to 127.0.0.1
+      url: "http://127.0.0.1:5050"
     }
   }
   ...
@@ -459,9 +460,12 @@ module.exports = {
 
 ### Runtime network - Integrated Devnet
 
-We provide a option to use [starknet-devnet](https://github.com/Shard-Labs/starknet-devnet) as a network without a need to run it as a separate process. By default, it will use the latest Docker image of Devnet listening on `http://127.0.0.1:5000`.
+We provide the option to use [starknet-devnet](https://github.com/Shard-Labs/starknet-devnet) as a network without the need to run it as a separate process. By default, it will use the latest Docker image of Devnet listening on `http://127.0.0.1:5050`.
 
-Additionaly, you can use a specified Python environment or a different Docker image by defining the `networks["integratedDevnet"]`.
+Additionaly, by defining `networks["integratedDevnet"]`, you can specify:
+
+-   a Python environment with starknet-devnet preinstalled
+-   a different Docker image.
 
 ```javascript
 module.exports = {
@@ -470,10 +474,12 @@ module.exports = {
   },
   networks: {
     integratedDevnet: {
-      url: "http://127.0.0.1:5000",
+      url: "http://127.0.0.1:5050",
+
       // venv: "active" <- for the active virtual environment
       // venv: "path/to/my-venv" <- for env created with e.g. `python -m venv path/to/my-venv`
       venv: "<VENV-PATH>",
+
       // or specify Docker image tag
       dockerizedVersion: "0.1.18"
     }
@@ -539,17 +545,20 @@ function deployAccount(accountType: AccountImplementationType, options?: DeployA
 ```
 
 -   `accountType` - the implementation of the Account that you want to use; currently supported implementations:
-    - `"OpenZeppelin"`
-    - `"Argent"`
+    -   `"OpenZeppelin"`
+    -   `"Argent"`
 -   `options` - optional deployment parameters:
     -   `salt` - for fixing the account address
     -   `privateKey` - if you don't provide one, it will be randomly generated
     -   `token` - for indicating that the account is whitelisted on alpha-mainnet
 
 Use it like this:
+
 ```typescript
 const account = await starknet.deployAccount("OpenZeppelin");
-const accountWithPredefinedKey = await starknet.deployAccount("OpenZeppelin", { privateKey: process.env.MY_KEY });
+const accountWithPredefinedKey = await starknet.deployAccount("OpenZeppelin", {
+    privateKey: process.env.MY_KEY
+});
 ```
 
 To retrieve an already deployed Account, use the `starknet` object's `getAccountFromAddress` method:

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "CAIRO_LANG": "0.8.1",
-    "STARKNET_DEVNET": "0.1.23"
+    "STARKNET_DEVNET": "0.2.0"
 }

--- a/scripts/check-devnet-is-not-running.sh
+++ b/scripts/check-devnet-is-not-running.sh
@@ -3,7 +3,7 @@ set -e
 
 check_devnet_is_not_running() {
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:5000/feeder_gateway/is_alive") || echo "Devnet is not running! $status"
+    status=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:5050/feeder_gateway/is_alive") || echo "Devnet is not running! $status"
 
     if [ "$status" != 000 ]; then
         echo "Devnet is running and responded with status $status"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -86,7 +86,7 @@ echo "starknet-devnet at: $STARKNET_DEVNET_PATH"
 iterate_dir integrated-devnet
 
 # run devnet
-starknet-devnet --host 127.0.0.1 --port 5000 &
+starknet-devnet --host 127.0.0.1 --port 5050 &
 
 iterate_dir devnet
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,7 @@ export const CAIRO_CLI_DOCKER_REPOSITORY = "shardlabs/cairo-cli";
 export const CAIRO_CLI_DEFAULT_DOCKER_IMAGE_TAG = config["CAIRO_LANG"];
 export const DEVNET_DOCKER_REPOSITORY = "shardlabs/starknet-devnet";
 export const DEFAULT_DEVNET_DOCKER_IMAGE_TAG = config["STARKNET_DEVNET"];
-export const INTEGRATED_DEVNET_URL = "http://127.0.0.1:5000";
+export const INTEGRATED_DEVNET_URL = "http://127.0.0.1:5050";
 
 export const CAIRO_CLI_DOCKER_REPOSITORY_WITH_TAG = `${CAIRO_CLI_DOCKER_REPOSITORY}:${CAIRO_CLI_DEFAULT_DOCKER_IMAGE_TAG}`;
 

--- a/src/devnet/create-devnet-wrapper.ts
+++ b/src/devnet/create-devnet-wrapper.ts
@@ -22,7 +22,10 @@ export function createIntegratedDevnet(hre: HardhatRuntimeEnvironment): Integrat
     const { hostname, port } = new URL(devnetNetwork.url || INTEGRATED_DEVNET_URL);
 
     if (hostname !== "localhost" && hostname !== "127.0.0.1") {
-        throw new HardhatPluginError(PLUGIN_NAME, "Integreated devnet works only with localhost");
+        throw new HardhatPluginError(
+            PLUGIN_NAME,
+            "Integrated devnet works only with localhost and 127.0.0.1"
+        );
     }
 
     if (devnetNetwork.venv) {
@@ -32,7 +35,7 @@ export function createIntegratedDevnet(hre: HardhatRuntimeEnvironment): Integrat
     if (hostname === "localhost") {
         throw new HardhatPluginError(
             PLUGIN_NAME,
-            "Docker integrated devnet works only with 127.0.0.1 host"
+            "Dockerized integrated devnet works only with host 127.0.0.1"
         );
     }
 

--- a/src/devnet/docker-devnet.ts
+++ b/src/devnet/docker-devnet.ts
@@ -1,10 +1,10 @@
 import { HardhatDocker, Image } from "@nomiclabs/hardhat-docker";
 import { ChildProcess, spawn, spawnSync } from "child_process";
-import { DEVNET_DOCKER_REPOSITORY } from "../constants";
 
 import { IntegratedDevnet } from "./integrated-devnet";
 
 const CONTAINER_NAME = "integrated-devnet";
+const DEVNET_DOCKER_INTERNAL_PORT = 5050;
 
 export class DockerDevnet extends IntegratedDevnet {
     private docker: HardhatDocker;
@@ -36,8 +36,8 @@ export class DockerDevnet extends IntegratedDevnet {
             "--name",
             CONTAINER_NAME,
             "-p",
-            `${this.host}:${this.port}:5000`,
-            DEVNET_DOCKER_REPOSITORY
+            `${this.host}:${this.port}:${DEVNET_DOCKER_INTERNAL_PORT}`,
+            `${this.image.repository}:${this.image.tag}`
         ]);
     }
 

--- a/test/configuration-tests/with-account-compilation-option/hardhat.config.ts
+++ b/test/configuration-tests/with-account-compilation-option/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-artifacts-path/hardhat.config.ts
+++ b/test/configuration-tests/with-artifacts-path/hardhat.config.ts
@@ -9,7 +9,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-cairo-version/hardhat.config.ts
+++ b/test/configuration-tests/with-cairo-version/hardhat.config.ts
@@ -7,7 +7,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-cli-network/hardhat.config.ts
+++ b/test/configuration-tests/with-cli-network/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-cli-paths/hardhat.config.ts
+++ b/test/configuration-tests/with-cli-paths/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-deploy-inputs/hardhat.config.ts
+++ b/test/configuration-tests/with-deploy-inputs/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-deploy-path/hardhat.config.ts
+++ b/test/configuration-tests/with-deploy-path/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-disable-hint-compilation-option/hardhat.config.ts
+++ b/test/configuration-tests/with-disable-hint-compilation-option/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-networks/hardhat.config.ts
+++ b/test/configuration-tests/with-networks/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-sources-path/hardhat.config.ts
+++ b/test/configuration-tests/with-sources-path/hardhat.config.ts
@@ -9,7 +9,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/configuration-tests/with-wait/hardhat.config.ts
+++ b/test/configuration-tests/with-wait/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/account-test/hardhat.config.ts
+++ b/test/general-tests/account-test/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/constructor-test/hardhat.config.ts
+++ b/test/general-tests/constructor-test/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/devnet-restart/hardhat.config.ts
+++ b/test/general-tests/devnet-restart/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/function-argument-number/hardhat.config.ts
+++ b/test/general-tests/function-argument-number/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/hardhat-run/hardhat.config.ts
+++ b/test/general-tests/hardhat-run/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/plain/hardhat.config.ts
+++ b/test/general-tests/plain/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/postman/hardhat.config.ts
+++ b/test/general-tests/postman/hardhat.config.ts
@@ -9,7 +9,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/starknet-call/hardhat.config.ts
+++ b/test/general-tests/starknet-call/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/starknet-estimate-fee/hardhat.config.ts
+++ b/test/general-tests/starknet-estimate-fee/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/starknet-invoke/hardhat.config.ts
+++ b/test/general-tests/starknet-invoke/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/starknet-verify/hardhat.config.ts
+++ b/test/general-tests/starknet-verify/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/transaction-signing/hardhat.config.ts
+++ b/test/general-tests/transaction-signing/hardhat.config.ts
@@ -6,7 +6,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/general-tests/wallet-test/hardhat.config.ts
+++ b/test/general-tests/wallet-test/hardhat.config.ts
@@ -3,7 +3,7 @@ import "../dist/src/index.js";
 module.exports = {
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     },
     starknet: {

--- a/test/integrated-devnet-tests/with-active-venv/hardhat.config.ts
+++ b/test/integrated-devnet-tests/with-active-venv/hardhat.config.ts
@@ -7,7 +7,7 @@ module.exports = {
     networks: {
         integratedDevnet: {
             venv: "active",
-            url: "http://127.0.0.1:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/integrated-devnet-tests/with-docker/hardhat.config.ts
+++ b/test/integrated-devnet-tests/with-docker/hardhat.config.ts
@@ -7,7 +7,7 @@ module.exports = {
     networks: {
         integratedDevnet: {
             dockerizedVersion: process.env.STARKNET_DEVNET,
-            url: "http://127.0.0.1:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/integrated-devnet-tests/with-venv/hardhat.config.ts
+++ b/test/integrated-devnet-tests/with-venv/hardhat.config.ts
@@ -7,7 +7,7 @@ module.exports = {
     networks: {
         integratedDevnet: {
             venv: process.env.STARKNET_DEVNET_PATH,
-            url: "http://127.0.0.1:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/venv-tests/with-venv-active/hardhat.config.ts
+++ b/test/venv-tests/with-venv-active/hardhat.config.ts
@@ -7,7 +7,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };

--- a/test/venv-tests/with-venv/hardhat.config.ts
+++ b/test/venv-tests/with-venv/hardhat.config.ts
@@ -7,7 +7,7 @@ module.exports = {
     },
     networks: {
         devnet: {
-            url: "http://localhost:5000"
+            url: "http://127.0.0.1:5050"
         }
     }
 };


### PR DESCRIPTION
## Usage related changes
- Adapt to starknet-devnet 0.2.0

## Development related changes
- Use 127.0.0.1:5050 across tests:
  - Even though the majority of tests would work just fine without this intervention, integrated-devnet tests (or at least those using default values), had to be adapted to the new 5050 port. And to have a uniform port across all the tests, all occurences of port 5000 were replaced with 5050 (and localhost with 127.0.0.1).
- Fix used Node documentation.

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example): https://github.com/Shard-Labs/starknet-hardhat-example/pull/59
