### PR TITLE
Make url optional for hardhat network config

### DIFF
--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -71,14 +71,14 @@ declare module "hardhat/types/config" {
     }
 
     export interface HardhatNetworkConfig {
-        url: string;
+        url?: string;
         venv?: string;
         dockerizedVersion?: string;
         starknetChainId?: string;
     }
 
     export interface HardhatNetworkUserConfig {
-        url: string;
+        url?: string;
         venv?: string;
         dockerizedVersion?: string;
     }

--- a/test/configuration-tests/with-networks/hardhat.config.ts
+++ b/test/configuration-tests/with-networks/hardhat.config.ts
@@ -7,6 +7,7 @@ module.exports = {
     networks: {
         devnet: {
             url: "http://127.0.0.1:5050"
-        }
+        },
+        hardhat: {}
     }
 };


### PR DESCRIPTION
## Usage related changes
- Fix issue with `hardhat` network being configured in hardhat.config.ts
- Make `url` an **optional** property of `HardhatNetworkUserConfig`.

## Development related changes
- Introduce hardhat network entry to hardhat.config.ts used in the network configuration test.

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I didn't have to create a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
