### PR TITLE
Added getter for starknetContract.address in Account class

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ More detailed documentation can be found [here](#account).
     const account = await starknet.deployAccount("OpenZeppelin");
     // or
     const account = await starknet.getAccountFromAddress(accountAddress, process.env.PRIVATE_KEY, "OpenZeppelin");
-    console.log("Account:", account.starknetContract.address, account.privateKey, account.publicKey);
+    console.log("Account:", account.address, account.privateKey, account.publicKey);
 
     const { res: currBalance } = await account.call(contract, "get_balance");
     const amount = BigInt(10);

--- a/src/account.ts
+++ b/src/account.ts
@@ -57,6 +57,10 @@ export abstract class Account {
         ).toString();
     }
 
+    get address() {
+        return this.starknetContract.address;
+    }
+
     /**
      * Uses the account contract as a proxy to call a function on the target contract with a signature
      *


### PR DESCRIPTION
## Usage related changes
- Until now users had to do `account.starknetContract.address`, but now they could just do `account.address`


## Development related changes
- Added address getter for `account.starknetContract.address` to Account class

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example): https://github.com/Shard-Labs/starknet-hardhat-example/pull/60