### PR TITLE
Release v0.5.5

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "CAIRO_LANG": "0.8.2.1",
-    "STARKNET_DEVNET": "0.2.1"
+    "STARKNET_DEVNET": "0.2.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@shardlabs/starknet-hardhat-plugin",
-            "version": "0.5.4",
+            "version": "0.5.5",
             "license": "ISC",
             "dependencies": {
                 "@nomiclabs/hardhat-docker": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "description": "Plugin for using Starknet tools within Hardhat projects",
     "main": "dist/src/index.js",
     "files": [


### PR DESCRIPTION
## Usage related changes
- Release v0.5.5
- Make integrated-devnet use devnet v0.2.2 by default

## Development related changes
- Use devnet v0.2.2 for testing

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [ ] I have documented the changes
- [ ] I have updated the tests
- [ ] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
