### PR TITLE
Time manipulation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,17 @@ Devnet can be restarted by calling `starknet.devnet.restart()`. All of the deplo
 await starknet.devnet.restart();
 ```
 
+#### Time Advancing
+
+The time offset for each generated block can be increased by calling `starknet.devnet.increaseTime()`, and the time for the next block can be set by calling  `starknet.devnet.setTime()` and subsequent blocks will keep the set offset.
+
+Warning: *block time can be set in the past and lead to unexpected behaviour!*
+
+```typescript
+await starknet.devnet.setTime(1000); // time in seconds
+await starknet.devnet.increaseTime(1000); // time in seconds
+```
+
 ## Configure the plugin
 
 Specify custom configuration by editing your project's `hardhat.config.ts` (or `hardhat.config.js`).

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -35,8 +35,16 @@ export interface LoadL1MessagingContractResponse {
     l1_provider: string;
 }
 
+export interface SetTimeResponse {
+    next_block_timestamp: number;
+}
+
+export interface IncreaseTimeResponse {
+    timestamp_increased_by: number;
+}
+
 export class DevnetUtils implements Devnet {
-    constructor(private hre: HardhatRuntimeEnvironment) {}
+    constructor(private hre: HardhatRuntimeEnvironment) { }
 
     private get endpoint() {
         return `${this.hre.config.starknet.networkUrl}`;
@@ -78,5 +86,27 @@ export class DevnetUtils implements Devnet {
 
             return response.data;
         }, "Request failed. Make sure your network has the /postman endpoint");
+    }
+
+    public async increaseTime(seconds: number) {
+        return this.withErrorHandler<IncreaseTimeResponse>(async () => {
+            const response = await axios.post<IncreaseTimeResponse>(
+                `${this.endpoint}/increase_time`,
+                {
+                    time: seconds
+                });
+            return response.data;
+        }, "Request failed. Make sure your network has the /increase_time endpoint");
+    }
+
+    public async setTime(seconds: number) {
+        return this.withErrorHandler<SetTimeResponse>(async () => {
+            const response = await axios.post<SetTimeResponse>(
+                `${this.endpoint}/set_time`,
+                {
+                    time: seconds
+                });
+            return response.data;
+        }, "Request failed. Make sure your network has the /set_time endpoint");
     }
 }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -213,7 +213,7 @@ declare module "hardhat/types/runtime" {
 
             /**
              * Returns an entire block and the transactions contained within it.
-             * @param optional block identifier (by block number or hash). To query the latest block, remove the identifier.
+             * @param identifier optional block identifier (by block number or hash). To query the latest block, remove the identifier.
              * @returns a block object
              */
             getBlock: (identifier?: BlockIdentifier) => Promise<Block>;

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -9,7 +9,7 @@ import {
     StringMap
 } from "./types";
 import { StarknetWrapper } from "./starknet-wrappers";
-import { FlushResponse, LoadL1MessagingContractResponse } from "./devnet-utils";
+import { FlushResponse, IncreaseTimeResponse, LoadL1MessagingContractResponse, SetTimeResponse } from "./devnet-utils";
 import { Account, ArgentAccount, OpenZeppelinAccount } from "./account";
 import { Transaction, TransactionReceipt, Block } from "./starknet-types";
 import { HardhatNetworkConfig, NetworkConfig } from "hardhat/types/config";
@@ -121,6 +121,21 @@ declare module "hardhat/types/runtime" {
             address?: string,
             networkId?: string
         ) => Promise<LoadL1MessagingContractResponse>;
+
+
+        /**
+         * Increases the block timestamp offset.
+         * @param seconds the new timestamp in seconds
+         * @returns a timestamp
+         */
+        increaseTime: (seconds: number) => Promise<IncreaseTimeResponse>;
+
+        /**
+         * Sets the block timestamp offset.
+         * @param seconds the new timestamp offset in seconds
+         * @returns a timestamp offset
+         */
+        setTime: (seconds: number) => Promise<SetTimeResponse>;
     }
 
     interface HardhatRuntimeEnvironment {

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -123,16 +123,16 @@ declare module "hardhat/types/runtime" {
         ) => Promise<LoadL1MessagingContractResponse>;
 
         /**
-         * Increases the block time by the given time.
-         * @param seconds the new timestamp in seconds
-         * @returns a timestamp
+         * Increases block time offset
+         * @param seconds the offset increase in seconds
+         * @returns an object containing the increased block time offset
          */
         increaseTime: (seconds: number) => Promise<IncreaseTimeResponse>;
 
         /**
          * Sets the timestamp of next block
-         * @param seconds the new timestamp in seconds
-         * @returns a timestamp offset
+         * @param seconds timestamp in seconds
+         * @returns an object containg next block timestamp
          */
         setTime: (seconds: number) => Promise<SetTimeResponse>;
     }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -122,17 +122,16 @@ declare module "hardhat/types/runtime" {
             networkId?: string
         ) => Promise<LoadL1MessagingContractResponse>;
 
-
         /**
-         * Increases the block timestamp offset.
+         * Increases the block time by the given time.
          * @param seconds the new timestamp in seconds
          * @returns a timestamp
          */
         increaseTime: (seconds: number) => Promise<IncreaseTimeResponse>;
 
         /**
-         * Sets the block timestamp offset.
-         * @param seconds the new timestamp offset in seconds
+         * Sets the timestamp of next block
+         * @param seconds the new timestamp in seconds
          * @returns a timestamp offset
          */
         setTime: (seconds: number) => Promise<SetTimeResponse>;


### PR DESCRIPTION
## Usage related changes
- Block timestamp can be handled using the two devnet functions `increaseTime()` and `setTime()`

## Development related changes
- `setTime()` wil update the subsequent block timestamp keeping the offset

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [x] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
