### PR TITLE
Adapt to new Voyager verification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ The verifier expects `<COMPILER_VERSION>` to be passed on request. Supported com
 
 For `<LICENSE_SCHEME>` the command takes [*No License (None)*](https://github.com/github/choosealicense.com/blob/a40ef42140d137770161addf4fefc715709d8ccd/no-permission.md) as default license scheme. [Here](https://goerli.voyager.online/cairo-licenses) is a list of available options.
 
-Use `<CONTRACT_NAME>` if the account is different than what is passed in `<PATH>`.
-
 ### `starknet-deploy-account`
 
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You would typically use the input feature when deploying a single contract requi
 ### `starknet-verify`
 
 ```
-npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPENDENCY_PATH> ...] [--address <CONTRACT_ADDRESS>] [--compiler-version <COMPILER_VERSION>] [--license <LICENSE_SCHEME>]
+npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPENDENCY_PATH> ...] [--address <CONTRACT_ADDRESS>] [--compiler-version <COMPILER_VERSION>] [--license <LICENSE_SCHEME>] [--contract-name <CONTRACT_NAME>] [--acount-contract <BOOLEAN>]
 ```
 
 Queries [Voyager](https://voyager.online/) to [verify the contract](https://voyager.online/verifyContract) deployed at `<CONTRACT_ADDRESS>` using the source files at `<PATH>` and any number of `<DEPENDENCY_PATH>`.
@@ -115,6 +115,8 @@ Like in the previous command, this plugin relies on `--starknet-network`, but wi
 The verifier expects `--compiler-version` to be passed on request. The following are supported compiler versions. `0.6.0`, `0.6.1`, `0.6.2`, `0.7.0`, `0.7.1`, `0.8.0`, and `0.8.1`.
 
 For `--license` the command takes [*No License (None)*](https://github.com/github/choosealicense.com/blob/a40ef42140d137770161addf4fefc715709d8ccd/no-permission.md) as default license scheme. [Here](https://goerli.voyager.online/cairo-licenses) is a list of available options.
+
+Use `--contract-name` if the account is different than what is passed in `--path`. Both `--contract-name` and `--account-contract` are optional arguments.
 
 ### `starknet-deploy-account`
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,16 @@ You would typically use the input feature when deploying a single contract requi
 ### `starknet-verify`
 
 ```
-npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPENDENCY_PATH> ...] [--address <CONTRACT_ADDRESS>]
+npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPENDENCY_PATH> ...] [--address <CONTRACT_ADDRESS>] [--compiler-version <COMPILER_VERSION>] [--license <LICENSE_SCHEME>]
 ```
 
 Queries [Voyager](https://voyager.online/) to [verify the contract](https://voyager.online/verifyContract) deployed at `<CONTRACT_ADDRESS>` using the source files at `<PATH>` and any number of `<DEPENDENCY_PATH>`.
 
 Like in the previous command, this plugin relies on `--starknet-network`, but will default to 'alpha' network in case this parameter is not passed.
+
+The verifier expects `--compiler-version` to be passed on request. The following are supported compiler versions. `0.6.0`, `0.6.1`, `0.6.2`, `0.7.0`, `0.7.1`, `0.8.0`, and `0.8.1`.
+
+For `--license` the command takes [*No License (None)*](https://github.com/github/choosealicense.com/blob/a40ef42140d137770161addf4fefc715709d8ccd/no-permission.md) as default license scheme. [Here](https://goerli.voyager.online/cairo-licenses) is a list of available options.
 
 ### `starknet-deploy-account`
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Queries [Voyager](https://voyager.online/) to [verify the contract](https://voya
 
 Like in the previous command, this plugin relies on `--starknet-network`, but will default to 'alpha' network in case this parameter is not passed.
 
-The verifier expects `--compiler-version` to be passed on request. The following are supported compiler versions. `0.6.0`, `0.6.1`, `0.6.2`, `0.7.0`, `0.7.1`, `0.8.0`, and `0.8.1`.
+The verifier expects `--compiler-version` to be passed on request. Supported compiler versions are listed [here](https://voyager.online/verifyContract) in the dropdown menu.
 
 For `--license` the command takes [*No License (None)*](https://github.com/github/choosealicense.com/blob/a40ef42140d137770161addf4fefc715709d8ccd/no-permission.md) as default license scheme. [Here](https://goerli.voyager.online/cairo-licenses) is a list of available options.
 

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ Queries [Voyager](https://voyager.online/) to [verify the contract](https://voya
 
 Like in the previous command, this plugin relies on `--starknet-network`, but will default to 'alpha' network in case this parameter is not passed.
 
-The verifier expects `--compiler-version` to be passed on request. Supported compiler versions are listed [here](https://voyager.online/verifyContract) in the dropdown menu.
+The verifier expects `<COMPILER_VERSION>` to be passed on request. Supported compiler versions are listed [here](https://voyager.online/verifyContract) in the dropdown menu.
 
-For `--license` the command takes [*No License (None)*](https://github.com/github/choosealicense.com/blob/a40ef42140d137770161addf4fefc715709d8ccd/no-permission.md) as default license scheme. [Here](https://goerli.voyager.online/cairo-licenses) is a list of available options.
+For `<LICENSE_SCHEME>` the command takes [*No License (None)*](https://github.com/github/choosealicense.com/blob/a40ef42140d137770161addf4fefc715709d8ccd/no-permission.md) as default license scheme. [Here](https://goerli.voyager.online/cairo-licenses) is a list of available options.
 
-Use `--contract-name` if the account is different than what is passed in `--path`. Both `--contract-name` and `--account-contract` are optional arguments.
+Use `<CONTRACT_NAME>` if the account is different than what is passed in `<PATH>`.
 
 ### `starknet-deploy-account`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,6 +260,8 @@ task("starknet-verify", "Verifies a contract on a Starknet network.")
     .addParam("address", "The address where the contract is deployed")
     .addParam("compilerVersion", "The compiler version used to compile the cairo contract")
     .addOptionalParam("license", "The licence of the contract (e.g MIT License (MIT))")
+    .addOptionalParam("accountContract", "Tells whether the contract is of type account or not")
+    .addOptionalParam("contractName", "The name of the contract")
     .addOptionalVariadicPositionalParam(
         "paths",
         "The paths of the dependencies of the contract specified in --path" +

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,9 +259,8 @@ task("starknet-verify", "Verifies a contract on a Starknet network.")
     .addParam("path", "The path of the main cairo contract (e.g. contracts/contract.cairo)")
     .addParam("address", "The address where the contract is deployed")
     .addParam("compilerVersion", "The compiler version used to compile the cairo contract")
-    .addOptionalParam("license", "The licence of the contract (e.g MIT License (MIT))")
-    .addOptionalParam("accountContract", "Tells whether the contract is of type account or not")
-    .addOptionalParam("contractName", "The name of the contract")
+    .addOptionalParam("license", "The licence of the contract (e.g No License (None))")
+    .addOptionalParam("contractName", "The name of the main contract (e.g. contract.cairo)")
     .addOptionalVariadicPositionalParam(
         "paths",
         "The paths of the dependencies of the contract specified in --path" +

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,6 +258,8 @@ task("starknet-verify", "Verifies a contract on a Starknet network.")
     .addOptionalParam("starknetNetwork", "The network version to be used (e.g. alpha)")
     .addParam("path", "The path of the main cairo contract (e.g. contracts/contract.cairo)")
     .addParam("address", "The address where the contract is deployed")
+    .addParam("compilerVersion", "The compiler version used to compile the cairo contract")
+    .addOptionalParam("license", "The licence of the contract (e.g MIT License (MIT))")
     .addOptionalVariadicPositionalParam(
         "paths",
         "The paths of the dependencies of the contract specified in --path" +

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,6 @@ task("starknet-verify", "Verifies a contract on a Starknet network.")
     .addParam("address", "The address where the contract is deployed")
     .addParam("compilerVersion", "The compiler version used to compile the cairo contract")
     .addOptionalParam("license", "The licence of the contract (e.g No License (None))")
-    .addOptionalParam("contractName", "The name of the main contract (e.g. contract.cairo)")
     .addOptionalVariadicPositionalParam(
         "paths",
         "The paths of the dependencies of the contract specified in --path" +

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -347,7 +347,7 @@ async function handleContractVerification(
         paths.push(...args.paths);
     }
 
-    const sourceRegex = new RegExp("^" + hre.config.paths?.starknetSources + "/");
+    const sourceRegex = new RegExp("^" + hre.config.paths.starknetSources + "/");
     const contractNameDefault = mainPath.replace(sourceRegex, "");
     // If contract name is not provided, use the default
     bodyFormData.append("contract-name", args.contractName || contractNameDefault);

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -341,7 +341,6 @@ async function handleContractVerification(
     const bodyFormData = new FormData();
     bodyFormData.append("compiler-version", args.compilerVersion);
     bodyFormData.append("license", args.license || "No License (None)");
-    bodyFormData.append("account-contract", args.accountContract || "false");
 
     // Dependencies (non-main contracts) are in args.paths
     if (args.paths) {

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -350,7 +350,7 @@ async function handleContractVerification(
     const sourceRegex = new RegExp("^" + hre.config.paths.starknetSources + "/");
     const contractNameDefault = mainPath.replace(sourceRegex, "");
     // If contract name is not provided, use the default
-    bodyFormData.append("contract-name", args.contractName || contractNameDefault);
+    bodyFormData.append("contract-name", contractNameDefault);
     // Appends all contracts to the form data with the name "file" + index
     handleMultiPartContractVerification(bodyFormData, paths, hre.config.paths.root, sourceRegex);
 
@@ -362,7 +362,7 @@ async function handleContractVerification(
                 PLUGIN_NAME,
                 `\
 Could not verify the contract at address ${args.address}.
-${err.response.data.message ? err.response.data.message :
+${err.response.data.message ||
                     `It is hard to tell exactly what happened, but possible reasons include:
 - Deployment transaction hasn't been accepted or indexed yet (check its tx_status or try in a minute)
 - Wrong contract address

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -351,7 +351,7 @@ async function handleContractVerification(
     const sourceRegex = new RegExp("^" + hre.config.paths?.starknetSources + "/");
     const contractNameDefault = mainPath.replace(sourceRegex, "");
     // If contract name is not provided, use the default
-    bodyFormData.append("contract-name", args.contractName ? args.contractName : contractNameDefault);
+    bodyFormData.append("contract-name", args.contractName || contractNameDefault);
     // Appends all contracts to the form data with the name "file" + index
     handleMultiPartContractVerification(bodyFormData, paths, hre.config.paths.root, sourceRegex);
 

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -355,15 +355,10 @@ async function handleContractVerification(
     // Appends all contracts to the form data with the name "file" + index
     handleMultiPartContractVerification(bodyFormData, paths, hre.config.paths.root, sourceRegex);
 
-    await axios({
-        method: "POST",
-        url: voyagerUrl,
-        data: bodyFormData,
-        headers: {
-            "Content-Type": `multipart/form-data; boundary=${bodyFormData.getBoundary()}`
-        }
-    })
-        .catch((err) => {
+    await axios
+        .post(voyagerUrl, bodyFormData.getBuffer(), {
+            headers: bodyFormData.getHeaders()
+        }).catch((err) => {
             throw new HardhatPluginError(
                 PLUGIN_NAME,
                 `\

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -9,7 +9,7 @@ UTIL_CONTRACT=contracts/util.cairo
 npx hardhat starknet-compile $MAIN_CONTRACT $UTIL_CONTRACT
 
 echo "Waiting for deployment to be accepted"
-output=$(npx hardhat starknet-deploy --starknet-network "$NETWORK" starknet-artifacts/$MAIN_CONTRACT --inputs 10 --wait)
+output=$(npx hardhat starknet-deploy --starknet-network "$NETWORK" contract --inputs 10 --wait)
 address=$(echo $output | sed -r "s/.*Contract address: (\w*).*/\1/")
 
 echo "Sleeping to allow Voyager to index the deployment"

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -11,13 +11,14 @@ npx hardhat starknet-compile $MAIN_CONTRACT $UTIL_CONTRACT
 echo "Waiting for deployment to be accepted"
 output=$(npx hardhat starknet-deploy --starknet-network "$NETWORK" contract --inputs 10 --wait)
 address=$(echo $output | sed -r "s/.*Contract address: (\w*).*/\1/")
+echo "Verifying contract at $address"
 
 echo "Sleeping to allow Voyager to index the deployment"
 sleep 1m
 
-echo "Verifying contract at $address"
-
 npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address --compiler-version 0.8.1 --license "No License (None)"
+echo "Sleeping to allow Voyager to register the verification"
+sleep 15s
 
 is_verified=$(curl "https://goerli.voyager.online/api/contract/$address/code" | jq ".abiVerified")
 if [ "$is_verified" == "true" ]; then

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 
-echo "Temporarily disabled. Uncomment the tests once we receive API instructions from the Voyager team (Nethermind)"
 
 # set -e
 
-# MAIN_CONTRACT=contracts/contract.cairo
-# UTIL_CONTRACT=contracts/util.cairo
+MAIN_CONTRACT=contracts/contract.cairo
+UTIL_CONTRACT=contracts/util.cairo
 
-# npx hardhat starknet-compile $MAIN_CONTRACT $UTIL_CONTRACT
+npx hardhat starknet-compile $MAIN_CONTRACT $UTIL_CONTRACT
 
-# echo "Waiting for deployment to be accepted"
-# output=$(npx hardhat starknet-deploy --starknet-network "$NETWORK" contract --inputs 10 --wait)
-# address=$(echo $output | sed -r "s/.*Contract address: (\w*).*/\1/")
+echo "Waiting for deployment to be accepted"
+output=$(npx hardhat starknet-deploy --starknet-network "$NETWORK" starknet-artifacts/$MAIN_CONTRACT --inputs 10 --wait)
+address=$(echo $output | sed -r "s/.*Contract address: (\w*).*/\1/")
 
-# echo "Sleeping to allow Voyager to index the deployment"
-# sleep 1m
+echo "Sleeping to allow Voyager to index the deployment"
+sleep 1m
 
-# echo "Verifying contract at $address"
-# npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address
+echo "Verifying contract at $address"
 
-# is_verified=$(curl "https://goerli.voyager.online/api/contract/$address/code" | jq ".abiVerified")
-# if [ "$is_verified" == "true" ]; then
-#     echo "Successfully verified!"
-# else
-#     echo "$0: Error: Not verified!"
-#     exit 1
-# fi
+npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address --compiler-version 0.8.1 --license "No License (None)"
+
+is_verified=$(curl "https://goerli.voyager.online/api/contract/$address/code" | jq ".abiVerified")
+if [ "$is_verified" == "true" ]; then
+    echo "Successfully verified!"
+else
+    echo "$0: Error: Not verified!"
+    exit 1
+fi

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-# set -e
+set -e
 
 MAIN_CONTRACT=contracts/contract.cairo
 UTIL_CONTRACT=contracts/util.cairo


### PR DESCRIPTION
## Usage related changes
- Plugin now supports contract verification on multiple directory levels.
- Additionally, the verifier accepts
- More details on [readme](https://github.com/Shard-Labs/starknet-hardhat-plugin/tree/voyager#starknet-verify).
```
- Compiler Version
- License scheme
- Contract Name (optional)
- Account Contract (optional)
```

## Development related changes
- `filename` changed to `filepath` when appending to the payload using `FormData`

# Checklist:

- [x] I have formatted the code
- [x] I have performed a self-review of the code
- [x] I have rebased to the base branch
- [x] I have documented the changes
- [x] I have updated the tests
- [ ] I have created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example).
