### PR TITLE
Support dump and load endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,22 @@ Devnet can be restarted by calling `starknet.devnet.restart()`. All of the deplo
 await starknet.devnet.restart();
 ```
 
+#### Dumping
+
+Use `starknet.devnet.dump()` to maintain the Devnet instance from the plugin.
+
+```typescript
+await starknet.devnet.dump(path); // path to dump file (eg. dump.pkl)
+```
+
+#### Loading
+
+Dumped Devnet instance can be loaded using `starknet.devnet.load()`.
+
+```typescript
+await starknet.devnet.load(path); // path for dump file (eg. dump.pkl)
+```
+
 #### Advancing time
 
 The plugin comes with support for [Devnet's timestamp management](https://github.com/Shard-Labs/starknet-devnet/#advancing-time).

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-git clone -b dump-and-load --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
+git clone -b plugin --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
 cd starknet-hardhat-example
 git log -n 1
 npm install

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-git clone -b plugin --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
+git clone -b dump-and-load --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
 cd starknet-hardhat-example
 git log -n 1
 npm install

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -112,9 +112,10 @@ export class DevnetUtils implements Devnet {
 
     public async dump(path: string) {
         return this.withErrorHandler<void>(async () => {
-            await axios.post(`${this.endpoint}/dump`, {
-                path
-            });
+            await axios.post(`${this.endpoint}/dump`,
+                {
+                    path
+                });
         }, "Request failed. Make sure your network has the /dump endpoint");
     }
 

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -109,4 +109,22 @@ export class DevnetUtils implements Devnet {
             return response.data;
         }, "Request failed. Make sure your network has the /set_time endpoint");
     }
+
+    public async dump(path: string) {
+        return this.withErrorHandler<void>(async () => {
+            await axios.post(`${this.endpoint}/dump`, {
+                path
+            });
+        }, "Request failed. Make sure your network has the /dump endpoint");
+    }
+
+    public async load(path: string) {
+        return this.withErrorHandler<void>(async () => {
+            await axios.post(
+                `${this.endpoint}/load`,
+                {
+                    path
+                });
+        }, "Request failed. Make sure your network has the /load endpoint");
+    }
 }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -143,6 +143,20 @@ declare module "hardhat/types/runtime" {
          * @returns an object containg next block timestamp
          */
         setTime: (seconds: number) => Promise<SetTimeResponse>;
+
+        /**
+         * Preserves devnet instance to a file
+         * @param path  path for the dumping
+         * @return void
+         */
+        dump: (path: string) => Promise<void>;
+
+        /**
+         * Loads stored Starknet chain state
+         * @param path  path for the dump file
+         * @returns void
+         */
+        load: (path: string) => Promise<void>;
     }
 
     interface HardhatRuntimeEnvironment {

--- a/test/general-tests/devnet-dump-and-load/check.sh
+++ b/test/general-tests/devnet-dump-and-load/check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+npx hardhat starknet-compile contracts/contract.cairo
+npx hardhat test --no-compile test/devnet-dump-and-load.test.ts

--- a/test/general-tests/devnet-dump-and-load/hardhat.config.ts
+++ b/test/general-tests/devnet-dump-and-load/hardhat.config.ts
@@ -1,0 +1,12 @@
+import "../dist/src/index.js";
+
+module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
+    networks: {
+        devnet: {
+            url: "http://127.0.0.1:5050"
+        }
+    }
+};

--- a/test/general-tests/devnet-dump-and-load/network.json
+++ b/test/general-tests/devnet-dump-and-load/network.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../network.schema",
+    "devnet": true
+}


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-  Support for `/dump` and `/load` devnet endpoints.

## Development related changes
- None

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors
-   [x] Tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory
-   [x] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example/pull/69):
    -   [x] Modified `test.sh` to use my example repo branch
    -   [x] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [x] All tests are passing
