### PR TITLE
Fix logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,12 +637,14 @@ await account.invoke(contract, "increase_balance", { amount });
     -   Give it finds through [the faucet](https://faucet.goerli.starknet.io/).
     -   Later load the account using `starknet.getAccountFromAddress`.
 -   **On starknet-devnet**
-    -   Since v0.2.3, Devnet comes with prefunded accounts which use the OpenZeppelin account implementation.
-    -   Use the data logged by Devnet on startup (address, key)
+    -   Since v0.2.3, Devnet comes with prefunded OpenZeppelin accounts.
+    -   To get the addresses and keys of these accounts, the options are:
+        -   use `starknet.devnet.getPredeployedAccounts()`
+        -   observe data logged on Devnet startup
     -   Load one of the predeployed accounts using `starknet.getAccountFromAddress`
     -   [Read more](https://github.com/Shard-Labs/starknet-devnet#predeployed-accounts)
 
-Once your account has funds, you can specify a maximum fee greater than zero:
+Once your account has funds, you can specify a max fee greater than zero:
 
 ```typescript
 await account.invoke(contract, "foo", { arg1: ... }, { maxFee: BigInt(...) });

--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -149,7 +149,9 @@ export function adaptInputUtil(
         const inputSpec = inputSpecs[i];
         const currentValue = input[inputSpec.name];
         if (inputSpec.type === "felt") {
-            const errorMsg = `${functionName}: Expected ${inputSpec.name} to be a felt`;
+            const errorMsg =
+                `${functionName}: Expected "${inputSpec.name}" to be a felt (Numeric); ` +
+                `got: ${typeof currentValue}`;
             if (isNumeric(currentValue)) {
                 adapted.push(toNumericString(currentValue));
             } else if (inputSpec.name.endsWith(LEN_SUFFIX)) {

--- a/src/starknet-types.ts
+++ b/src/starknet-types.ts
@@ -35,6 +35,10 @@ export interface EventSpecification {
     type: "event";
 }
 
+export interface EventAbi {
+    [encodedName: string]: EventSpecification;
+}
+
 export type AbiEntry = CairoFunction | Struct | EventSpecification;
 
 export interface Abi {

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,7 +211,7 @@ export async function iterativelyCheckStatus(
         reject(
             new Error(
                 "Transaction rejected. Error message:\n\n" +
-                    statusObject.tx_failure_reason.error_message
+                    adaptLog(statusObject.tx_failure_reason.error_message)
             )
         );
     } else {
@@ -613,7 +613,7 @@ export class StarknetContract {
                 this.feederGatewayUrl,
                 () => resolve(txHash),
                 (error) => {
-                    console.error(`Invoke transaction ${txHash} is REJECTED.\n` + error.message);
+                    console.error(`Invoke transaction ${txHash} is REJECTED.`);
                     reject(error);
                 }
             );
@@ -740,7 +740,7 @@ export class StarknetContract {
         for (let i = 0; i < eventNames.length; i++) {
             const event = <starknet.EventSpecification>this.abi[eventNames[i]];
             if (!event) {
-                const msg = `Event name '${eventNames[i]}' doesn't exist on ${this.abiPath}.`;
+                const msg = `Event "${eventNames[i]}" doesn't exist in ${this.abiPath}.`;
                 throw new HardhatPluginError(PLUGIN_NAME, msg);
             }
             const adapted = adaptOutputUtil(rawEvents[i], event.data, this.abi);
@@ -763,7 +763,7 @@ export class StarknetContract {
             // encoded event name guaranteed to be at index 0
             const eventSpecifications = this.eventsSpecifications[event.keys[0]];
             if (!eventSpecifications) {
-                const msg = `Event specifications '${event.keys[0]}' doesn't exist on ${this.abiPath}.`;
+                const msg = `Event "${event.keys[0]}" doesn't exist in ${this.abiPath}.`;
                 throw new HardhatPluginError(PLUGIN_NAME, msg);
             }
             eventNames.push(eventSpecifications.name);

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,7 +259,7 @@ function handleSignature(signature: Array<Numeric>): string[] {
  * @returns an object mapping ABI entry names with their values.
  */
 function extractEventSpecifications(abi: starknet.Abi) {
-    const events: { [encodedName: string]: starknet.EventSpecification } = {};
+    const events: starknet.EventAbi = {};
     for (const abiEntryName in abi) {
         if (abi[abiEntryName].type === "event") {
             const event = <starknet.EventSpecification>abi[abiEntryName];
@@ -519,7 +519,7 @@ export class StarknetContractFactory {
 export class StarknetContract {
     private starknetWrapper: StarknetWrapper;
     private abi: starknet.Abi;
-    private eventsSpecifications: starknet.Abi;
+    private eventsSpecifications: starknet.EventAbi;
     private abiPath: string;
     private networkID: string;
     private chainID: string;
@@ -730,44 +730,25 @@ export class StarknetContract {
     }
 
     /**
-     * Adapt `Event` to something more readable .
-     * @param eventNames  an array of the event's name that was emitted
-     * @param rawEvents array of  the events output as as unparsed space separated string
-     * @returns structured output
-     */
-    private adaptEvent(eventNames: string[], rawEvents: string[]) {
-        const events: DecodedEvent[] = [];
-        for (let i = 0; i < eventNames.length; i++) {
-            const event = <starknet.EventSpecification>this.abi[eventNames[i]];
-            if (!event) {
-                const msg = `Event "${eventNames[i]}" doesn't exist in ${this.abiPath}.`;
-                throw new HardhatPluginError(PLUGIN_NAME, msg);
-            }
-            const adapted = adaptOutputUtil(rawEvents[i], event.data, this.abi);
-            events.push({ name: event.name, data: adapted });
-        }
-        return events;
-    }
-
-    /**
      * Decode the events to a structured object with parameter names.
      * @param events as received from the server.
      * @returns structured object with parameter names.
      */
     async decodeEvents(events: starknet.Event[]): Promise<DecodedEvent[]> {
-        const rawEvents: string[] = [];
-        const eventNames: string[] = [];
+        const decodedEvents: DecodedEvent[] = [];
         for (const event of events) {
-            const result = event.data.map(BigInt).join(" ");
-            rawEvents.push(result);
+            const rawEventData = event.data.map(BigInt).join(" ");
             // encoded event name guaranteed to be at index 0
-            const eventSpecifications = this.eventsSpecifications[event.keys[0]];
-            if (!eventSpecifications) {
+            const eventSpecification = this.eventsSpecifications[event.keys[0]];
+            if (!eventSpecification) {
                 const msg = `Event "${event.keys[0]}" doesn't exist in ${this.abiPath}.`;
                 throw new HardhatPluginError(PLUGIN_NAME, msg);
             }
-            eventNames.push(eventSpecifications.name);
+
+            const adapted = adaptOutputUtil(rawEventData, eventSpecification.data, this.abi);
+            decodedEvents.push({ name: eventSpecification.name, data: adapted });
         }
-        return this.adaptEvent(eventNames, rawEvents);
+
+        return decodedEvents;
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,9 @@ export function adaptLog(msg: string): string {
     return msg
         .replace("--network", "--starknet-network")
         .replace("gateway_url", "gateway-url")
-        .replace("--account_contract", "--account-contract");
+        .replace("--account_contract", "--account-contract")
+        .split(".\nTraceback (most recent call last)")[0] // remove duplicated log
+        .replace(/\\n/g, "\n"); // use newlines from json response for formatting
 }
 
 const DOCKER_HOST = "host.docker.internal";


### PR DESCRIPTION
## Usage related changes

- Closes #136:
  - This stems from multiple sources, just one is log-and-throw done in the plugin, the rest comes from the way Starknet CLI handles errors (this was addressed in a hacky way, by pattern matching) 
- Improve error logging if wrong type provided as function input
- Update docs with `getPredeployedAccounts` usage.
- Improve formatting of error messages (unescape escaped newlines)

## Development related changes

- Refactor event decoding:
  - incorporate `adaptEvent` into `decodeEvents`
  - introduce type `EventAbi`

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors
-   [x] Tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Linked issues which this PR resolves