### PR TITLE
state: add dump/load timeout and wait until dump has finished

### DIFF
--- a/src/devnet/integrated-devnet.ts
+++ b/src/devnet/integrated-devnet.ts
@@ -3,7 +3,7 @@ import { ChildProcess } from "child_process";
 import { HardhatPluginError } from "hardhat/plugins";
 import { PLUGIN_NAME } from "../constants";
 
-function sleep(amountMillis: number): Promise<void> {
+export function sleep(amountMillis: number): Promise<void> {
     return new Promise((resolve) => {
         setTimeout(resolve, amountMillis);
     });


### PR DESCRIPTION

## Usage related changes

<!-- How the changes from this PR affect users. -->

-   If underlying server dies, the timeouts will make sure the plugin does not freeze
-   It checks correctly until dump file has finished writing, otherwise immediate load would cause everything to explode

Resolves #167 

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors
-   [x] Tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [x] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
