### PR TITLE
Adapt to cairo-lang/starknet 0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ More detailed documentation can be found [here](#account).
 ```typescript
 it("should estimate fee", async function () {
     const fee = await contract.estimateFee("increase_balance", { amount: 10n });
-    console.log("Estimated fee:", fee.amount, fee.unit);
+    console.log("Estimated fee:", fee.amount, fee.unit, fee.gas_price, fee.gas_amount);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ await account.invoke(contract, "increase_balance", { amount });
         -   observe data logged on Devnet startup
     -   Load one of the predeployed accounts using `starknet.getAccountFromAddress`
     -   [Read more](https://github.com/Shard-Labs/starknet-devnet#predeployed-accounts)
-    -   Alternatively use [Devnet's faucet](https://github.com/Shard-Labs/starknet-devnet#mint-token---local-faucet) to give funds to the accounts that you deployed
+    -   Alternatively use [Devnet's faucet](https://github.com/Shard-Labs/starknet-devnet#mint-token---local-faucet) to fund the accounts that you deployed
 
 Once your account has funds, you can specify a max fee greater than zero:
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "CAIRO_LANG": "0.9.0",
+    "CAIRO_LANG": "0.9.1",
     "STARKNET_DEVNET": "0.2.5"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "CAIRO_LANG": "0.9.1",
-    "STARKNET_DEVNET": "0.2.5"
+    "STARKNET_DEVNET": "0.2.6"
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-git clone -b plugin --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
+git clone -b adapt-0.9.1 --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
 cd starknet-hardhat-example
 git log -n 1
 npm install

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-git clone -b adapt-0.9.1 --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
+git clone -b plugin --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
 cd starknet-hardhat-example
 git log -n 1
 npm install

--- a/src/account.ts
+++ b/src/account.ts
@@ -3,7 +3,6 @@ import {
     ContractInteractionFunction,
     DeployAccountOptions,
     EstimateFeeOptions,
-    FeeEstimation,
     InteractChoice,
     InteractOptions,
     InvokeOptions,
@@ -12,6 +11,7 @@ import {
     StarknetContract,
     StringMap
 } from "./types";
+import * as starknet from "./starknet-types";
 import { PLUGIN_NAME, TransactionHashPrefix } from "./constants";
 import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
@@ -105,7 +105,7 @@ export abstract class Account {
         functionName: string,
         calldata?: StringMap,
         options?: EstimateFeeOptions
-    ): Promise<FeeEstimation> {
+    ): Promise<starknet.FeeEstimation> {
         return await this.interact(
             InteractChoice.ESTIMATE_FEE,
             toContract,
@@ -170,7 +170,7 @@ export abstract class Account {
     async multiEstimateFee(
         callParameters: CallParameters[],
         options?: EstimateFeeOptions
-    ): Promise<FeeEstimation> {
+    ): Promise<starknet.FeeEstimation> {
         return await this.multiInteract(InteractChoice.ESTIMATE_FEE, callParameters, options);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,7 +270,7 @@ task("starknet-verify", "Verifies a contract on a Starknet network.")
     .addOptionalParam("license", "The licence of the contract (e.g No License (None))")
     .addOptionalVariadicPositionalParam(
         "paths",
-        "The paths of the dependencies of the contract specified in --path" +
+        "The paths of the dependencies of the contract specified in --path\n" +
             "All dependencies should be in the same folder as the contract." +
             "e.g. path/to/dependency1 path/to/dependency2"
     )

--- a/src/starknet-types.ts
+++ b/src/starknet-types.ts
@@ -114,3 +114,16 @@ export interface Block {
     transaction_receipts: TransactionReceipt[];
     transactions: TransactionData[];
 }
+
+export type TxFailureReason = {
+    code: string;
+    error_message: string;
+    tx_id: string;
+};
+
+export type FeeEstimation = {
+    amount: bigint;
+    unit: string;
+    gas_price: bigint;
+    gas_usage: bigint;
+};

--- a/src/starknet-types.ts
+++ b/src/starknet-types.ts
@@ -113,6 +113,7 @@ export interface Block {
     timestamp: number;
     transaction_receipts: TransactionReceipt[];
     transactions: TransactionData[];
+    starknet_version: string;
 }
 
 export type TxFailureReason = {

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -103,7 +103,8 @@ export abstract class StarknetWrapper {
             "--contract",
             options.contract,
             "--gateway_url",
-            options.gatewayUrl
+            options.gatewayUrl,
+            "--no_wallet"
         ];
 
         if (options.signature && options.signature.length) {
@@ -125,7 +126,8 @@ export abstract class StarknetWrapper {
             "--contract",
             options.contract,
             "--gateway_url",
-            options.gatewayUrl
+            options.gatewayUrl,
+            "--no_wallet"
         ];
 
         if (options.inputs && options.inputs.length) {


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- Updated estimateFee response, but without changing `amount` to `overall_fee`, just added the new properties (`gas_price`, `gas_usage`) - keeping them snake case to be in sync with other responses coming from the sequencer API.
- Updated Block structure (`starknet_version`).

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Passing `--no_wallet` to Starknet CLI where necessary.
- Tests failing until proper devnet release is done.
- Close https://github.com/Shard-Labs/starknet-hardhat-plugin/issues/154
- Moved appropriate types to `starknet-types.ts`

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors
-   [x] Tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [ ] Linked issues which this PR resolves
-   [x] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   https://github.com/Shard-Labs/starknet-hardhat-example/pull/73
    -   [x] Modified `test.sh` to use my example repo branch
    -   [x] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
