### PR TITLE
Add new param to voyager verifier API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You would typically use the input feature when deploying a single contract requi
 ### `starknet-verify`
 
 ```
-npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPENDENCY_PATH> ...] [--address <CONTRACT_ADDRESS>] [--compiler-version <COMPILER_VERSION>] [--license <LICENSE_SCHEME>] [--contract-name <CONTRACT_NAME>] [--acount-contract <BOOLEAN>]
+npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPENDENCY_PATH> ...] [--address <CONTRACT_ADDRESS>] [--compiler-version <COMPILER_VERSION>] [--license <LICENSE_SCHEME>] [--contract-name <CONTRACT_NAME>] [--acount-contract]
 ```
 
 Queries [Voyager](https://voyager.online/) to [verify the contract](https://voyager.online/verifyContract) deployed at `<CONTRACT_ADDRESS>` using the source files at `<PATH>` and any number of `<DEPENDENCY_PATH>`.
@@ -114,6 +114,8 @@ Queries [Voyager](https://voyager.online/) to [verify the contract](https://voya
 Like in the previous command, this plugin relies on `--starknet-network`, but will default to 'alpha' network in case this parameter is not passed.
 
 The verifier expects `<COMPILER_VERSION>` to be passed on request. Supported compiler versions are listed [here](https://voyager.online/verifyContract) in the dropdown menu.
+
+We pass `--acount-contract` to tell the verifier that the contract is of type account.
 
 For `<LICENSE_SCHEME>` the command takes [_No License (None)_](https://github.com/github/choosealicense.com/blob/a40ef42140d137770161addf4fefc715709d8ccd/no-permission.md) as default license scheme. [Here](https://goerli.voyager.online/cairo-licenses) is a list of available options.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,7 @@ task("starknet-verify", "Verifies a contract on a Starknet network.")
     .addParam("path", "The path of the main cairo contract (e.g. contracts/contract.cairo)")
     .addParam("address", "The address where the contract is deployed")
     .addParam("compilerVersion", "The compiler version used to compile the cairo contract")
+    .addOptionalParam("accountContract", "The contract type which specifies whether it's an account contract. Omiting it sets false.")
     .addOptionalParam("license", "The licence of the contract (e.g No License (None))")
     .addOptionalVariadicPositionalParam(
         "paths",

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -338,6 +338,7 @@ async function handleContractVerification(
 
     const bodyFormData = new FormData();
     bodyFormData.append("compiler-version", args.compilerVersion);
+    bodyFormData.append("account-contract", args.accountContract ? "true" : "false");
     bodyFormData.append("license", args.license || "No License (None)");
 
     // Dependencies (non-main contracts) are in args.paths

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -16,7 +16,7 @@ echo "Verifying contract at $address"
 echo "Sleeping to allow Voyager to index the deployment"
 sleep 1m
 
-npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address --compiler-version 0.8.1 --license "No License (None)"
+npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address --compiler-version 0.9.0 --license "No License (None)"
 echo "Sleeping to allow Voyager to register the verification"
 sleep 15s
 


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   The Voyager verification API expects `account-contract` as a param.

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors
-   [x] Tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
