### PR TITLE
Use proxy server in VenvWrapper

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -97,6 +97,7 @@ There are two wrappers around Starknet CLI. They are defined in [starknet-wrappe
 -   Venv wrapper:
     -   for users that already have `cairo-lang` installed
     -   faster than Docker wrapper
+    -   sends Starknet CLI commands to a [proxy server](/src/starknet_cli_wrapper.py) which has the `main` method of Starknet CLI imported.
 
 ## Version management
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.6.3-alpha.2",
+    "version": "0.6.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@shardlabs/starknet-hardhat-plugin",
-            "version": "0.6.3-alpha.2",
+            "version": "0.6.2",
             "license": "ISC",
             "dependencies": {
                 "@nomiclabs/hardhat-docker": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.6.3-alpha",
+    "version": "0.6.3-alpha.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@shardlabs/starknet-hardhat-plugin",
-            "version": "0.6.3-alpha",
+            "version": "0.6.3-alpha.1",
             "license": "ISC",
             "dependencies": {
                 "@nomiclabs/hardhat-docker": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.6.2",
+    "version": "0.6.3-alpha",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@shardlabs/starknet-hardhat-plugin",
-            "version": "0.6.2",
+            "version": "0.6.3-alpha",
             "license": "ISC",
             "dependencies": {
                 "@nomiclabs/hardhat-docker": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.6.3-alpha.1",
+    "version": "0.6.3-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@shardlabs/starknet-hardhat-plugin",
-            "version": "0.6.3-alpha.1",
+            "version": "0.6.3-alpha.2",
             "license": "ISC",
             "dependencies": {
                 "@nomiclabs/hardhat-docker": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "test-general-tests": "TEST_SUBDIR=general-tests ./scripts/test.sh",
         "test-venv-tests": "TEST_SUBDIR=venv-tests ./scripts/test.sh",
         "test-integrated-devnet-tests": "TEST_SUBDIR=integrated-devnet-tests ./scripts/test.sh",
-        "build": "rm -rf dist && tsc",
+        "build": "rm -rf dist && tsc && npm run copy-files",
+        "copy-files": "cp src/starknet_cli_wrapper.py dist/src/",
         "lint": "eslint src test"
     },
     "author": "Shard-Labs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.6.2",
+    "version": "0.6.3-alpha",
     "description": "Plugin for using Starknet tools within Hardhat projects",
     "main": "dist/src/index.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.6.3-alpha.1",
+    "version": "0.6.3-alpha.2",
     "description": "Plugin for using Starknet tools within Hardhat projects",
     "main": "dist/src/index.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.6.3-alpha.2",
+    "version": "0.6.2",
     "description": "Plugin for using Starknet tools within Hardhat projects",
     "main": "dist/src/index.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shardlabs/starknet-hardhat-plugin",
-    "version": "0.6.3-alpha",
+    "version": "0.6.3-alpha.1",
     "description": "Plugin for using Starknet tools within Hardhat projects",
     "main": "dist/src/index.js",
     "files": [

--- a/src/devnet/create-devnet-wrapper.ts
+++ b/src/devnet/create-devnet-wrapper.ts
@@ -11,9 +11,9 @@ import {
 import { getImageTagByArch, getNetwork } from "../utils";
 import { DockerDevnet } from "./docker-devnet";
 import { VenvDevnet } from "./venv-devnet";
-import { IntegratedDevnet } from "./integrated-devnet";
+import { ExternalServer } from "./external-server";
 
-export function createIntegratedDevnet(hre: HardhatRuntimeEnvironment): IntegratedDevnet {
+export function createIntegratedDevnet(hre: HardhatRuntimeEnvironment): ExternalServer {
     const devnetNetwork = getNetwork<HardhatNetworkConfig>(
         INTEGRATED_DEVNET,
         hre.config.networks,

--- a/src/devnet/docker-devnet.ts
+++ b/src/devnet/docker-devnet.ts
@@ -1,17 +1,17 @@
 import { HardhatDocker, Image } from "@nomiclabs/hardhat-docker";
 import { ChildProcess, spawn, spawnSync } from "child_process";
 
-import { IntegratedDevnet } from "./integrated-devnet";
+import { ExternalServer } from "./external-server";
 
 const CONTAINER_NAME = "integrated-devnet";
 const DEVNET_DOCKER_INTERNAL_PORT = 5050;
 
-export class DockerDevnet extends IntegratedDevnet {
+export class DockerDevnet extends ExternalServer {
     private docker: HardhatDocker;
     private args?: string[];
 
     constructor(private image: Image, host: string, port: string, args?: string[]) {
-        super(host, port);
+        super(host, port, "is_alive", "integrated-devnet");
         this.args = args;
     }
 

--- a/src/devnet/external-server.ts
+++ b/src/devnet/external-server.ts
@@ -86,7 +86,7 @@ export abstract class ExternalServer {
                 this.childProcess = null;
                 if (code !== 0 && isAbnormalExit) {
                     if (this.connected) {
-                        const msg = `${this.processName} exited with code=${code} while processing transactions`;
+                        const msg = `${this.processName} spawned and connected successfully, but later exited with code=${code}`;
                         throw new HardhatPluginError(PLUGIN_NAME, msg);
                     } else {
                         const msg = `${this.processName} connect exited with code=${code}:\n${this.lastError}`;

--- a/src/devnet/external-server.ts
+++ b/src/devnet/external-server.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import net from "net";
 import { ChildProcess } from "child_process";
 import { HardhatPluginError } from "hardhat/plugins";
 import { PLUGIN_NAME } from "../constants";
@@ -6,6 +7,22 @@ import { PLUGIN_NAME } from "../constants";
 function sleep(amountMillis: number): Promise<void> {
     return new Promise((resolve) => {
         setTimeout(resolve, amountMillis);
+    });
+}
+
+export async function getFreePort() {
+    return new Promise((resolve, reject) => {
+        const srv = net.createServer();
+        srv.listen(0, () => {
+            const port = (srv.address() as net.AddressInfo).port;
+            srv.close((err) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(port);
+                }
+            });
+        });
     });
 }
 

--- a/src/devnet/external-server.ts
+++ b/src/devnet/external-server.ts
@@ -10,7 +10,7 @@ function sleep(amountMillis: number): Promise<void> {
     });
 }
 
-export async function getFreePort() {
+export async function getFreePort(): Promise<string> {
     return new Promise((resolve, reject) => {
         const srv = net.createServer();
         srv.listen(0, () => {
@@ -19,7 +19,7 @@ export async function getFreePort() {
                 if (err) {
                     reject(err);
                 } else {
-                    resolve(port);
+                    resolve(port.toString());
                 }
             });
         });
@@ -33,7 +33,7 @@ export abstract class ExternalServer {
 
     constructor(
         protected host: string,
-        protected port: string,
+        protected port: string | null,
         private isAliveURL: string,
         private processName: string
     ) {

--- a/src/devnet/index.ts
+++ b/src/devnet/index.ts
@@ -1,2 +1,2 @@
-export { IntegratedDevnet } from "./integrated-devnet";
+export { ExternalServer } from "./external-server";
 export { createIntegratedDevnet } from "./create-devnet-wrapper";

--- a/src/devnet/venv-devnet.ts
+++ b/src/devnet/venv-devnet.ts
@@ -1,14 +1,14 @@
 import { ChildProcess, spawn } from "child_process";
 
 import { getPrefixedCommand, normalizeVenvPath } from "../utils/venv";
-import { IntegratedDevnet } from "./integrated-devnet";
+import { ExternalServer } from "./external-server";
 
-export class VenvDevnet extends IntegratedDevnet {
+export class VenvDevnet extends ExternalServer {
     private command: string;
     private args?: string[];
 
     constructor(venvPath: string, host: string, port: string, args?: string[]) {
-        super(host, port);
+        super(host, port, "is_alive", "integrated-devnet");
 
         this.command = "starknet-devnet";
         this.args = args;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import { task, extendEnvironment, extendConfig } from "hardhat/config";
 import { HardhatPluginError, lazyObject } from "hardhat/plugins";
-import { HardhatConfig, HardhatUserConfig } from "hardhat/types";
+import { HardhatConfig, HardhatRuntimeEnvironment, HardhatUserConfig } from "hardhat/types";
 import exitHook from "exit-hook";
 
 import "./type-extensions";
@@ -50,11 +50,13 @@ import {
     getBlockUtil
 } from "./extend-utils";
 import { DevnetUtils } from "./devnet-utils";
-import { IntegratedDevnet } from "./devnet";
+import { ExternalServer } from "./devnet";
 import { StarknetChainId } from "starknet/constants";
+import { StarknetVenvProxy } from "./starknet-venv-proxy";
 
 exitHook(() => {
-    IntegratedDevnet.cleanAll();
+    ExternalServer.cleanAll();
+    StarknetVenvProxy.cleanAll();
 });
 
 // copy all user-defined cairo settings; other extendConfig calls will overwrite if needed
@@ -146,16 +148,20 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
     config.starknet.networkConfig = networkConfig;
 });
 
+function setVenvWrapper(hre: HardhatRuntimeEnvironment, venvPath: string) {
+    if (hre.config.starknet.dockerizedVersion) {
+        const msg =
+            "Error in config file. Only one of (starknet.dockerizedVersion, starknet.venv) can be specified.";
+        throw new HardhatPluginError(PLUGIN_NAME, msg);
+    }
+    hre.starknetWrapper = new VenvWrapper(venvPath);
+}
+
 // add venv wrapper or docker wrapper of starknet
 extendEnvironment((hre) => {
     const venvPath = hre.config.starknet.venv;
     if (venvPath) {
-        if (hre.config.starknet.dockerizedVersion) {
-            const msg =
-                "Error in config file. Only one of (starknet.dockerizedVersion, starknet.venv) can be specified.";
-            throw new HardhatPluginError(PLUGIN_NAME, msg);
-        }
-        hre.starknetWrapper = new VenvWrapper(venvPath);
+        setVenvWrapper(hre, venvPath);
     } else {
         const repository = CAIRO_CLI_DOCKER_REPOSITORY;
         const tag = getImageTagByArch(
@@ -267,7 +273,10 @@ task("starknet-verify", "Verifies a contract on a Starknet network.")
     .addParam("path", "The path of the main cairo contract (e.g. contracts/contract.cairo)")
     .addParam("address", "The address where the contract is deployed")
     .addParam("compilerVersion", "The compiler version used to compile the cairo contract")
-    .addOptionalParam("accountContract", "The contract type which specifies whether it's an account contract. Omitting it sets false.")
+    .addOptionalParam(
+        "accountContract",
+        "The contract type which specifies whether it's an account contract. Omitting it sets false."
+    )
     .addOptionalParam("license", "The licence of the contract (e.g No License (None))")
     .addOptionalVariadicPositionalParam(
         "paths",

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,11 +52,9 @@ import {
 import { DevnetUtils } from "./devnet-utils";
 import { ExternalServer } from "./devnet";
 import { StarknetChainId } from "starknet/constants";
-import { StarknetVenvProxy } from "./starknet-venv-proxy";
 
 exitHook(() => {
     ExternalServer.cleanAll();
-    StarknetVenvProxy.cleanAll();
 });
 
 // copy all user-defined cairo settings; other extendConfig calls will overwrite if needed

--- a/src/starknet-venv-proxy.ts
+++ b/src/starknet-venv-proxy.ts
@@ -1,15 +1,16 @@
 import { ChildProcess, spawn } from "child_process";
-import { ExternalServer } from "./devnet/external-server";
+import { ExternalServer, getFreePort } from "./devnet/external-server";
 import path from "path";
 
 export class StarknetVenvProxy extends ExternalServer {
     private started = false;
 
     constructor(private pythonPath: string) {
-        super("127.0.0.1", "8080", "", "starknet-venv-proxy");
+        super("127.0.0.1", null, "", "starknet-venv-proxy");
     }
 
     protected async spawnChildProcess(): Promise<ChildProcess> {
+        this.port = await getFreePort();
         const proxyServerPath = path.join(__dirname, "starknet_cli_wrapper.py");
         return spawn(this.pythonPath, [proxyServerPath, this.port]);
     }

--- a/src/starknet-venv-proxy.ts
+++ b/src/starknet-venv-proxy.ts
@@ -3,13 +3,15 @@ import { ExternalServer } from "./devnet/external-server";
 import path from "path";
 
 export class StarknetVenvProxy extends ExternalServer {
-    constructor(private started = false) {
+    private started = false;
+
+    constructor(private pythonPath: string) {
         super("127.0.0.1", "8080", "", "starknet-venv-proxy");
     }
 
     protected async spawnChildProcess(): Promise<ChildProcess> {
         const proxyServerPath = path.join(__dirname, "starknet_cli_wrapper.py");
-        return spawn("python", [proxyServerPath, this.port]);
+        return spawn(this.pythonPath, [proxyServerPath, this.port]);
     }
 
     public async ensureStarted(): Promise<void> {

--- a/src/starknet-venv-proxy.ts
+++ b/src/starknet-venv-proxy.ts
@@ -1,0 +1,26 @@
+import { ChildProcess, spawn } from "child_process";
+import { ExternalServer } from "./devnet/external-server";
+import path from "path";
+
+export class StarknetVenvProxy extends ExternalServer {
+    constructor(private started = false) {
+        super("127.0.0.1", "8080", "", "starknet-venv-proxy");
+    }
+
+    protected async spawnChildProcess(): Promise<ChildProcess> {
+        const proxyServerPath = path.join(__dirname, "starknet_cli_wrapper.py");
+        return spawn("python", [proxyServerPath, this.port]);
+    }
+
+    public async ensureStarted(): Promise<void> {
+        if (this.started) {
+            return;
+        }
+        await this.start();
+        this.started = true;
+    }
+
+    protected cleanup(): void {
+        this.childProcess?.kill();
+    }
+}

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -1,8 +1,10 @@
 import { HardhatDocker, Image, ProcessResult } from "@nomiclabs/hardhat-docker";
+import axios from "axios";
 import { spawnSync } from "child_process";
 import { HardhatPluginError } from "hardhat/plugins";
 import * as path from "path";
 import { PLUGIN_NAME } from "./constants";
+import { StarknetVenvProxy } from "./starknet-venv-proxy";
 import { BlockNumber, InteractChoice } from "./types";
 import { adaptUrl } from "./utils";
 import { getPrefixedCommand, normalizeVenvPath } from "./utils/venv";
@@ -532,25 +534,39 @@ export class DockerWrapper extends StarknetWrapper {
 
 export class VenvWrapper extends StarknetWrapper {
     private starknetCompilePath: string;
-    private starknetPath: string;
 
-    constructor(venvPath: string) {
+    constructor(venvPath: string, private starknetVenvproxy = new StarknetVenvProxy()) {
         super();
 
         if (venvPath === "active") {
             console.log(`${PLUGIN_NAME} plugin using the active environment.`);
             this.starknetCompilePath = "starknet-compile";
-            this.starknetPath = "starknet";
         } else {
             venvPath = normalizeVenvPath(venvPath);
             console.log(`${PLUGIN_NAME} plugin using environment at ${venvPath}`);
 
             this.starknetCompilePath = getPrefixedCommand(venvPath, "starknet-compile");
-            this.starknetPath = getPrefixedCommand(venvPath, "starknet");
         }
     }
 
-    private async execute(commandPath: string, preparedOptions: string[]): Promise<ProcessResult> {
+    /**
+     * Unlike `executeDirectly`, interacts with Starknet CLI through a server
+     * @param preparedOptions
+     * @returns
+     */
+    private async execute(preparedOptions: string[]): Promise<ProcessResult> {
+        await this.starknetVenvproxy.ensureStarted();
+        const response = await axios.post<ProcessResult>(this.starknetVenvproxy.url, {
+            args: preparedOptions
+        });
+
+        return response.data;
+    }
+
+    private async executeDirectly(
+        commandPath: string,
+        preparedOptions: string[]
+    ): Promise<ProcessResult> {
         const process = spawnSync(commandPath, preparedOptions);
 
         if (!process.stdout) {
@@ -566,55 +582,55 @@ export class VenvWrapper extends StarknetWrapper {
 
     public async compile(options: CompileWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareCompileOptions(options);
-        const executed = await this.execute(this.starknetCompilePath, preparedOptions);
+        const executed = await this.executeDirectly(this.starknetCompilePath, preparedOptions);
         return executed;
     }
 
     public async declare(options: DeclareWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareDeclareOptions(options);
-        const executed = await this.execute(this.starknetPath, preparedOptions);
+        const executed = await this.execute(preparedOptions);
         return executed;
     }
 
     public async deploy(options: DeployWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareDeployOptions(options);
-        const executed = await this.execute(this.starknetPath, preparedOptions);
+        const executed = await this.execute(preparedOptions);
         return executed;
     }
 
     public async interact(options: InteractWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareInteractOptions(options);
-        const executed = await this.execute(this.starknetPath, preparedOptions);
+        const executed = await this.execute(preparedOptions);
         return executed;
     }
 
     public async getTxStatus(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareTxQueryOptions("tx_status", options);
-        const executed = await this.execute(this.starknetPath, preparedOptions);
+        const executed = await this.execute(preparedOptions);
         return executed;
     }
 
     public async deployAccount(options: DeployAccountWrapperOptions): Promise<ProcessResult> {
         const deployAccountScript = this.getPythonDeployAccountScript(options);
-        const executed = await this.execute("python", ["-c", deployAccountScript]);
+        const executed = await this.executeDirectly("python", ["-c", deployAccountScript]);
         return executed;
     }
 
     public async getTransactionReceipt(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareTxQueryOptions("get_transaction_receipt", options);
-        const executed = await this.execute(this.starknetPath, preparedOptions);
+        const executed = await this.execute(preparedOptions);
         return executed;
     }
 
     public async getTransaction(options: TxHashQueryWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareTxQueryOptions("get_transaction", options);
-        const executed = await this.execute(this.starknetPath, preparedOptions);
+        const executed = await this.execute(preparedOptions);
         return executed;
     }
 
     public async getBlock(options: BlockQueryWrapperOptions): Promise<ProcessResult> {
         const preparedOptions = this.prepareBlockQueryOptions("get_block", options);
-        const executed = await this.execute(this.starknetPath, preparedOptions);
+        const executed = await this.execute(preparedOptions);
         return executed;
     }
 }

--- a/src/starknet_cli_wrapper.py
+++ b/src/starknet_cli_wrapper.py
@@ -31,6 +31,7 @@ class MyRequestHandler(BaseHTTPRequestHandler):
             return 1 # error exit code
 
     def do_GET(self):
+        """Useful for checking if server is alive."""
         self._set_headers()
 
     def do_POST(self):

--- a/src/starknet_cli_wrapper.py
+++ b/src/starknet_cli_wrapper.py
@@ -1,0 +1,62 @@
+"""Wrapper of Starknet CLI"""
+
+import asyncio
+from contextlib import redirect_stderr, redirect_stdout
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import io
+import json
+import sys
+
+from starkware.starknet.cli.starknet_cli import main
+
+class MyRequestHandler(BaseHTTPRequestHandler):
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+
+    def _get_args(self):
+        content_length = int(self.headers["Content-Length"])
+        raw_request_body = self.rfile.read(content_length).decode("utf-8")
+        return json.loads(raw_request_body)["args"]
+
+    exit_code = None
+
+    async def _execute(self):
+        args = self._get_args()
+        sys.argv = [sys.argv[0], *args]
+        try:
+            return await main()
+        except:
+            return 1 # error exit code
+
+    def do_GET(self):
+        self._set_headers()
+
+    def do_POST(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            event_loop = asyncio.get_event_loop()
+            self.exit_code = event_loop.run_until_complete(self._execute())
+
+        resp = {
+            "statusCode": self.exit_code,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue()
+        }
+
+        self._set_headers()
+        self.wfile.write(json.dumps(resp).encode("utf-8"))
+
+try:
+    port = int(sys.argv[1])
+except:
+    sys.exit("A numeric port must be specified")
+
+def run(server_class=HTTPServer, handler_class=MyRequestHandler):
+    server_address = ("", port)
+    httpd = server_class(server_address, handler_class)
+    httpd.serve_forever()
+
+run()


### PR DESCRIPTION
## Usage related changes

- Should only present a speed-up; no change in functionality.

## Development related changes

- Spawn a server that acts as an intermediary between user requests and Starknet CLI
  - `VenvWrapper` is modified to not spawn subprocesses (for most commands)
- Create a new abstract class `ExternalServer` which abstracts the previous `IntegratedDevnet` and the new `StarknetVenvProxy`.
- Something similar can be done for `DockerWrapper`. but in a separate PR (might include changing the cairo-cli docker image so that it includes the proxy server script).
- Not using `"python"` command directly in `VenvWrapper`, it is adapted in the constructor according to what the user specified as `venv` (`active` or not)
  - Now using proprety `pythonPath`

- Currently available on npm (`@sharlabs/starknet-hardhat-plugin`) and in [tags](https://github.com/Shard-Labs/starknet-hardhat-plugin/tags) as alpha versions:
  - `0.6.3-alpha` - CLI proxy listens on port 8080 (hardcoded)
  - `0.6.3-alpha.1` - CLI proxy listens on a randomly selected free port (subject to race condition)
  - `0.6.3-alpha.2` - CLI proxy listens on a port determined by polling ports 6050 (devnet default +1000), 7050, 8050, ... (stops on first free port)
    - what could be tried out (but would require more refactoring) is taking into accout if devnet is being used and use its port as the starting point for port search

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors
-   [x] Tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
-   [x] Restored version in package.json
