### PR TITLE
Add check to getBlockUtil

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "test-recompilation-tests": "TEST_SUBDIR=recompilation-tests ./scripts/test.sh",
         "build": "rm -rf dist && tsc && npm run copy-files",
         "copy-files": "cp src/starknet_cli_wrapper.py dist/src/",
-        "lint": "eslint src test"
+        "lint": "eslint src test",
+        "format": "prettier -wl src test"
     },
     "author": "Shard-Labs",
     "license": "ISC",

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -187,6 +187,11 @@ export async function getBlockUtil(
         hash: identifier?.blockHash
     };
 
+    if (identifier && typeof identifier !== "object") {
+        const msg = `Invalid identifier provided to getBlock: ${identifier}`;
+        throw new HardhatPluginError(PLUGIN_NAME, msg);
+    }
+
     if (blockOptions.number == null && !blockOptions.hash) {
         blockOptions.number = "latest";
     }

--- a/src/recompiler.ts
+++ b/src/recompiler.ts
@@ -22,7 +22,7 @@ export class Cache {
     protected cache: Record<string, ContractData> = {};
     public fsPromises = fs.promises;
 
-    constructor(protected hre: HardhatRuntimeEnvironment) { }
+    constructor(protected hre: HardhatRuntimeEnvironment) {}
 
     // Returns the contract data from the cache
     public async getCache(): Promise<Record<string, ContractData>> {
@@ -66,7 +66,10 @@ export class Cache {
     // Saves the cache to the file
     public async saveCache(): Promise<void> {
         const cacheFilePath = this.getCacheFilePath();
-        await this.fsPromises.writeFile(cacheFilePath, JSON.stringify(this.cache, null, " ") + "\n");
+        await this.fsPromises.writeFile(
+            cacheFilePath,
+            JSON.stringify(this.cache, null, " ") + "\n"
+        );
     }
 }
 
@@ -80,7 +83,9 @@ export class Recompiler {
     }
 
     // Gets hash of each .cairo file inside source
-    private async getContractHash(paths: ProjectPathsConfig): Promise<Record<string, ContractData>> {
+    private async getContractHash(
+        paths: ProjectPathsConfig
+    ): Promise<Record<string, ContractData>> {
         const { starknetSources: defaultSourcesPath } = paths;
 
         const sourceRegex = new RegExp("^" + defaultSourcesPath + "/");

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -26,7 +26,6 @@ import { getWalletUtil } from "./extend-utils";
 import { createIntegratedDevnet } from "./devnet";
 import { Recompiler } from "./recompiler";
 
-
 function checkSourceExists(sourcePath: string): void {
     if (!fs.existsSync(sourcePath)) {
         const msg = `Source expected to be at ${sourcePath}, but not found.`;


### PR DESCRIPTION
## Usage related changes

- Add check to getBlockUtil (the case when an object of type `any` is passed is not properly handled - defaulting to `"latest"` is done, which might be unwanted behavior if user passes number 2 (instead of passing as a property if the identifier object).

## Development related changes

- Add formatting script: `npm run format` (runs prettier and applies changes)

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
