### PR TITLE
Add createBlock wrapper

### DIFF
--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -140,4 +140,11 @@ export class DevnetUtils implements Devnet {
             });
         }, "Request failed. Make sure your network has the /load endpoint");
     }
+
+    public async createBlock() {
+        return this.withErrorHandler<void>(async () => {
+            await axios.post(`${this.endpoint}/create_block`, {
+            });
+        }, "Request failed. Make sure your network has the /create_block endpoint");
+    }
 }

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -143,8 +143,7 @@ export class DevnetUtils implements Devnet {
 
     public async createBlock() {
         return this.withErrorHandler<void>(async () => {
-            await axios.post(`${this.endpoint}/create_block`, {
-            });
+            await axios.post(`${this.endpoint}/create_block`, {});
         }, "Request failed. Make sure your network has the /create_block endpoint");
     }
 }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -165,6 +165,12 @@ declare module "hardhat/types/runtime" {
          * @returns void
          */
         load: (path: string) => Promise<void>;
+
+        /**
+         * Creates an empty block
+         * @returns void
+         */
+        createBlock: () => Promise<void>;
     }
 
     interface HardhatRuntimeEnvironment {

--- a/test/general-tests/devnet-create-block/check.sh
+++ b/test/general-tests/devnet-create-block/check.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+npx hardhat test --no-compile test/devnet-create-block-test.ts

--- a/test/general-tests/devnet-create-block/hardhat.config.ts
+++ b/test/general-tests/devnet-create-block/hardhat.config.ts
@@ -1,0 +1,12 @@
+import "../dist/src/index.js";
+
+module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
+    networks: {
+        devnet: {
+            url: "http://127.0.0.1:5050"
+        }
+    }
+};

--- a/test/general-tests/devnet-create-block/network.json
+++ b/test/general-tests/devnet-create-block/network.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../network.schema",
+    "devnet": true
+}


### PR DESCRIPTION
## Usage related changes

-   Adds a `createBlock` wrapper (accessible from `starknet.devnet.createBlock()`

## Development related changes

## Checklist:

-   [x] Formatted the code
-   [ ] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [x] Linked issues which this PR resolves -> None
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
