### PR TITLE
Add optional CLI param on hardhat run

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Estimates the gas fee of a function execution.
 
 ### `run`
 
-No CLI options introduced to the original `hardhat run`, but a starknet network can be specified using the config file. See [Runtime network](#runtime-network).
+Introduces the `--starknet-network` option to the existing `hardhat run` task.
 
 ### `test`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,4 +363,6 @@ task("test")
     .addOptionalParam("starknetNetwork", STARKNET_NETWORK_DESCRIPTION)
     .setAction(starknetTestAction);
 
-task("run").setAction(starknetRunAction);
+task("run")
+    .addOptionalParam("starknetNetwork", STARKNET_NETWORK_DESCRIPTION)
+    .setAction(starknetRunAction);

--- a/test/configuration-tests/with-cli-network/check.sh
+++ b/test/configuration-tests/with-cli-network/check.sh
@@ -6,5 +6,5 @@ set -e
 # It would be sufficient to run this test just once and not for both alpha and devnet.
 # Only tests if --starknet-network is accepted, not if the correct network is targeted.
 
-npx hardhat run     --no-compile scripts/compile-contract.ts
-npx hardhat test    --no-compile --starknet-network devnet test/quick-test.ts
+npx hardhat run --no-compile scripts/compile-contract.ts --starknet-network devnet
+npx hardhat test --no-compile --starknet-network devnet test/quick-test.ts

--- a/test/general-tests/hardhat-run/check.sh
+++ b/test/general-tests/hardhat-run/check.sh
@@ -3,4 +3,4 @@
 set -e
 
 npx hardhat starknet-compile contracts/contract.cairo
-npx hardhat run --no-compile scripts/quick-script.ts
+npx hardhat run --no-compile scripts/quick-script.ts --starknet-network "$NETWORK"

--- a/test/general-tests/hardhat-run/hardhat.config.ts
+++ b/test/general-tests/hardhat-run/hardhat.config.ts
@@ -2,7 +2,7 @@ import "../dist/src/index.js";
 
 module.exports = {
     starknet: {
-        network: "devnet"
+        network: process.env.NETWORK
     },
     networks: {
         devnet: {


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   `--starknet-network` can be passed to `npx hardhat run` command
-  Closes https://github.com/Shard-Labs/starknet-hardhat-plugin/issues/162

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [x] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
