### PR TITLE
Replace python with python3

### DIFF
--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -538,13 +538,13 @@ export class VenvWrapper extends StarknetWrapper {
         if (venvPath === "active") {
             console.log(`${PLUGIN_NAME} plugin using the active environment.`);
             this.starknetCompilePath = "starknet-compile";
-            this.pythonPath = "python";
+            this.pythonPath = "python3";
         } else {
             venvPath = normalizeVenvPath(venvPath);
             console.log(`${PLUGIN_NAME} plugin using environment at ${venvPath}`);
 
             this.starknetCompilePath = getPrefixedCommand(venvPath, "starknet-compile");
-            this.pythonPath = getPrefixedCommand(venvPath, "python");
+            this.pythonPath = getPrefixedCommand(venvPath, "python3");
         }
 
         this.starknetVenvProxy = new StarknetVenvProxy(this.pythonPath);


### PR DESCRIPTION
## Usage related changes

- Fix #189 

## Development related changes

- Use python3 instead of python when spawning subprocesses.

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Linked issues which this PR resolves