### PR TITLE
Add method to set custom implementation to contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,23 @@ it("should estimate fee", async function () {
 });
 ```
 
+#### Delegate Proxy
+
+```typescript
+it("should forward to the implementation contract", async function () {
+    const implementationFactory = await starknet.getContractFactory("contract");
+    const implementationClassHash = await implementationFactory.declare();
+
+    const proxyFactory = await starknet.getContractFactory("delegate_proxy");
+    const proxy = await proxyFactory.deploy({
+        implementation_hash_: implementationClassHash
+    });
+
+    proxy.setAbi(implementationFactory.abi, implementationFactory.abiPath);
+    const { res: initialProxyBalance } = await proxy.call("get_balance");
+});
+```
+
 #### Transaction information and receipt with events
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ it("should forward to the implementation contract", async function () {
         implementation_hash_: implementationClassHash
     });
 
-    proxy.setAbi(implementationFactory.abi, implementationFactory.abiPath);
+    proxy.setImplementation(implementationFactory);
     const { res: initialProxyBalance } = await proxy.call("get_balance");
 });
 ```

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-git clone -b set-abi-test --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
+git clone -b plugin --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
 cd starknet-hardhat-example
 git log -n 1
 npm install

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-git clone -b plugin --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
+git clone -b set-abi-test --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
 cd starknet-hardhat-example
 git log -n 1
 npm install

--- a/src/types.ts
+++ b/src/types.ts
@@ -545,9 +545,9 @@ export class StarknetContract {
      * @param abi abi of a deployed contract
      * @param abiPath path to the abi
      */
-    setAbi(abi: starknet.Abi, abiPath: string): void {
-        this.abi = abi;
-        this.abiPath = abiPath;
+    setImplementation(implementation: StarknetContractFactory): void {
+        this.abi = implementation.abi;
+        this.abiPath = implementation.abiPath;
     }
 
     private async interact(

--- a/src/types.ts
+++ b/src/types.ts
@@ -336,8 +336,8 @@ export interface BlockIdentifier {
 
 export class StarknetContractFactory {
     private starknetWrapper: StarknetWrapper;
-    private abi: starknet.Abi;
-    private abiPath: string;
+    public abi: starknet.Abi;
+    public abiPath: string;
     private constructorAbi: starknet.CairoFunction;
     private metadataPath: string;
     private networkID: string;
@@ -538,6 +538,16 @@ export class StarknetContract {
     set address(address: string) {
         this._address = address;
         return;
+    }
+
+    /**
+     * Set a custom abi and abi path to the contract
+     * @param abi abi of a deployed contract
+     * @param abiPath path to the abi
+     */
+    setAbi(abi: starknet.Abi, abiPath: string): void {
+        this.abi = abi;
+        this.abiPath = abiPath;
     }
 
     private async interact(

--- a/test/general-tests/proxy-call/check.sh
+++ b/test/general-tests/proxy-call/check.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+npx hardhat test --no-compile scripts/delegate-proxy.ts

--- a/test/general-tests/proxy-call/hardhat.config.ts
+++ b/test/general-tests/proxy-call/hardhat.config.ts
@@ -1,0 +1,13 @@
+import "../dist/src/index.js";
+
+module.exports = {
+    starknet: {
+        network: process.env.NETWORK,
+        recompile: true
+    },
+    networks: {
+        devnet: {
+            url: "http://127.0.0.1:5050"
+        }
+    }
+};

--- a/test/general-tests/proxy-call/network.json
+++ b/test/general-tests/proxy-call/network.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../network.schema",
+    "devnet": true
+}


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   Custom `abi` and `abiPath` can be set using `setAbi()` method.
-   Closes #151 

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [x] Linked issues which this PR resolves
-   [x] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):https://github.com/Shard-Labs/starknet-hardhat-example/pull/75
    -   [x] Modified `test.sh` to use my example repo branch
    -   [x] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
