### PR TITLE
Make account-contract a flag in starknet-verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You would typically use the input feature when deploying a single contract requi
 ### `starknet-verify`
 
 ```
-npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPENDENCY_PATH> ...] [--address <CONTRACT_ADDRESS>] [--compiler-version <COMPILER_VERSION>] [--license <LICENSE_SCHEME>] [--contract-name <CONTRACT_NAME>] [--acount-contract <BOOLEAN>]
+npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPENDENCY_PATH> ...] [--address <CONTRACT_ADDRESS>] [--compiler-version <COMPILER_VERSION>] [--license <LICENSE_SCHEME>] [--contract-name <CONTRACT_NAME>] [--acount-contract]
 ```
 
 Queries [Voyager](https://voyager.online/) to [verify the contract](https://voyager.online/verifyContract) deployed at `<CONTRACT_ADDRESS>` using the source files at `<PATH>` and any number of `<DEPENDENCY_PATH>`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,10 +293,7 @@ task("starknet-verify", "Verifies a contract on a Starknet network.")
     .addParam("path", "The path of the main cairo contract (e.g. contracts/contract.cairo)")
     .addParam("address", "The address where the contract is deployed")
     .addParam("compilerVersion", "The compiler version used to compile the cairo contract")
-    .addOptionalParam(
-        "accountContract",
-        "The contract type which specifies whether it's an account contract. Omitting it sets false."
-    )
+    .addFlag("accountContract", "The contract type which specifies it's an account contract.")
     .addOptionalParam("license", "The licence of the contract (e.g No License (None))")
     .addOptionalVariadicPositionalParam(
         "paths",

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -343,14 +343,7 @@ async function handleContractVerification(
 
     const bodyFormData = new FormData();
     bodyFormData.append("compiler-version", args.compilerVersion);
-    let accountContract;
-    if (args.accountContract === "true") {
-        accountContract = "true";
-    } else if (!args.accountContract || args.accountContract === "false") {
-        accountContract = "false";
-    } else {
-        throw new StarknetPluginError("--account-contract must be true or false");
-    }
+    const accountContract = args.accountContract ? "true" : "false";
     bodyFormData.append("account-contract", accountContract);
     bodyFormData.append("license", args.license || "No License (None)");
 

--- a/test/general-tests/starknet-verify/check.sh
+++ b/test/general-tests/starknet-verify/check.sh
@@ -19,7 +19,7 @@ echo "Verifying contract at $address"
 echo "Sleeping to allow Voyager to index the deployment"
 sleep 1m
 
-npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address --compiler-version 0.9.0 --license "No License (None)" --account-contract false
+npx hardhat starknet-verify --starknet-network "$NETWORK" --path $MAIN_CONTRACT $UTIL_CONTRACT --address $address --compiler-version 0.9.0 --license "No License (None)"
 echo "Sleeping to allow Voyager to register the verification"
 sleep 15s
 


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   Changes `--account-contract` optional param to a flag in `starknet-verify` cli.
-   Closes #173 

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [x] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
