### PR TITLE
Handle environment without starknet in proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,8 @@ If you want to use an existing Python virtual environment (pyenv, poetry, conda,
 
 To use the currently activated environment (or if you have the starknet commands globally installed), set `venv` to `"active"`.
 
+In any case, the specified environment is expected to contain the `python3` command.
+
 If you specify neither [dockerizedVersion](#cairo-version) nor `venv`, the latest dockerized version is used.
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -492,6 +492,8 @@ To use the currently activated environment (or if you have the starknet commands
 
 In any case, the specified environment is expected to contain the `python3` command.
 
+If you are on a Mac, you may experience Docker-related issues, so this may be the only way to run the plugin.
+
 If you specify neither [dockerizedVersion](#cairo-version) nor `venv`, the latest dockerized version is used.
 
 ```typescript

--- a/src/external-server/external-server.ts
+++ b/src/external-server/external-server.ts
@@ -129,15 +129,11 @@ export abstract class ExternalServer {
                 const isAbnormalExit = this.childProcess != null;
                 this.childProcess = null;
                 if (code !== 0 && isAbnormalExit) {
-                    if (this.stderr !== "STDERR") {
-                        console.error(this.lastError);
-                    }
-
                     const circumstance = this.connected ? "running" : "connecting";
                     const moreInfo = logger.isFile(this.stderr)
                         ? "More error info in " + this.stderr
                         : "";
-                    const msg = `${this.processName} exited with code=${code} while ${circumstance}. ${moreInfo}`;
+                    const msg = `${this.processName} exited with code=${code} while ${circumstance}. ${this.lastError}\n${moreInfo}`;
                     throw new StarknetPluginError(msg);
                 }
             });

--- a/src/starknet_cli_wrapper.py
+++ b/src/starknet_cli_wrapper.py
@@ -12,7 +12,7 @@ try:
     from starkware.starknet.cli.starknet_cli import main as starknet_main
     from starkware.starknet.compiler.compile import main as starknet_compile_main
 except ImportError:
-    sys.exit("Make sure the environment you configured has starknet installed (package name: cairo-lang)")
+    sys.exit("Make sure the environment you configured has starknet (cairo-lang) installed!")
 
 async def starknet_compile_main_wrapper():
     starknet_compile_main()

--- a/src/starknet_cli_wrapper.py
+++ b/src/starknet_cli_wrapper.py
@@ -7,9 +7,12 @@ import io
 import json
 import sys
 
-# imports resolvable in the venv specified by 
-from starkware.starknet.cli.starknet_cli import main as starknet_main
-from starkware.starknet.compiler.compile import main as starknet_compile_main
+# imports resolvable in the venv specified by user
+try:
+    from starkware.starknet.cli.starknet_cli import main as starknet_main
+    from starkware.starknet.compiler.compile import main as starknet_compile_main
+except ImportError:
+    sys.exit("Make sure the environment you configured has starknet installed (package name: cairo-lang)")
 
 async def starknet_compile_main_wrapper():
     starknet_compile_main()


### PR DESCRIPTION
## Usage related changes

- Close #195
- In case of abnormal external server exit, always log the last error from the subprocess.
- Updated docs with config-related information (python3, docker, mac).

## Development related changes

- Add try-except to `starknet_cli_wrapper.py` (proxy server).
- Expand error message thrown by external server in case of failure.

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Linked issues which this PR resolves
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
