### PR TITLE
Random port on integrated devnet

### DIFF
--- a/src/external-server/create-devnet-wrapper.ts
+++ b/src/external-server/create-devnet-wrapper.ts
@@ -10,15 +10,16 @@ import {
 import { getImageTagByArch, getNetwork } from "../utils";
 import { DockerDevnet } from "./docker-devnet";
 import { VenvDevnet } from "./venv-devnet";
-import { ExternalServer } from "./external-server";
+import { ExternalServer, getFreePort } from "./external-server";
 
-export function createIntegratedDevnet(hre: HardhatRuntimeEnvironment): ExternalServer {
+export async function createIntegratedDevnet(hre: HardhatRuntimeEnvironment): Promise<ExternalServer> {
     const devnetNetwork = getNetwork<HardhatNetworkConfig>(
         INTEGRATED_DEVNET,
         hre.config.networks,
         `networks["${INTEGRATED_DEVNET}"]`
     );
-    const { hostname, port } = new URL(devnetNetwork.url || INTEGRATED_DEVNET_URL);
+    const { hostname } = new URL(devnetNetwork.url || INTEGRATED_DEVNET_URL);
+    const port = await getFreePort();
 
     if (hostname !== "localhost" && hostname !== "127.0.0.1") {
         throw new StarknetPluginError("Integrated devnet works only with localhost and 127.0.0.1");

--- a/src/external-server/create-devnet-wrapper.ts
+++ b/src/external-server/create-devnet-wrapper.ts
@@ -12,7 +12,9 @@ import { DockerDevnet } from "./docker-devnet";
 import { VenvDevnet } from "./venv-devnet";
 import { ExternalServer, getFreePort } from "./external-server";
 
-export async function createIntegratedDevnet(hre: HardhatRuntimeEnvironment): Promise<ExternalServer> {
+export async function createIntegratedDevnet(
+    hre: HardhatRuntimeEnvironment
+): Promise<ExternalServer> {
     const devnetNetwork = getNetwork<HardhatNetworkConfig>(
         INTEGRATED_DEVNET,
         hre.config.networks,

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -553,7 +553,7 @@ async function runWithDevnet(hre: HardhatRuntimeEnvironment, fn: () => Promise<u
         return;
     }
 
-    const devnet = createIntegratedDevnet(hre);
+    const devnet = await createIntegratedDevnet(hre);
 
     await devnet.start();
     await fn();


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   Uses free random ports on integrated devnet
-   Closes #176 

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [x] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
