### PR TITLE
Fix missing compilation error

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -42,7 +42,7 @@ function iterate_dir() {
 
         network_file="$test_case/network.json"
 
-        if [[ -f "$network_file" ]]; then
+        if [[ ! -f "$network_file" ]]; then
             echo "Test failed! Error: No network file provided!"
             total=$((total + 1))
             continue

--- a/src/external-server/external-server.ts
+++ b/src/external-server/external-server.ts
@@ -3,8 +3,6 @@ import net from "net";
 import { ChildProcess } from "child_process";
 import { StarknetPluginError } from "../starknet-plugin-error";
 import { IntegratedDevnetLogger } from "./integrated-devnet-logger";
-import { HardhatPluginError } from "hardhat/plugins";
-import { PLUGIN_NAME } from "../constants";
 import { StringMap } from "../types";
 
 function sleep(amountMillis: number): Promise<void> {
@@ -168,7 +166,7 @@ export abstract class ExternalServer {
         } catch (error) {
             const parent = error instanceof Error && error;
             const msg = "Error in interaction with Starknet CLI proxy server";
-            throw new HardhatPluginError(PLUGIN_NAME, msg, parent);
+            throw new StarknetPluginError(msg, parent);
         }
     }
 

--- a/src/starknet_cli_wrapper.py
+++ b/src/starknet_cli_wrapper.py
@@ -22,7 +22,12 @@ async def starknet_main_wrapper(args):
 
 async def starknet_compile_main_wrapper(args):
     sys.argv = [sys.argv[0], *args]
-    return starknet_compile_main()
+    try:
+        return starknet_compile_main()
+    except Exception as err:
+        # stderr was previously redirected to our StringIO
+        print(err, file=sys.stderr)
+        return 1
 
 async def get_class_hash(args):
     path ,= args

--- a/test/configuration-tests/with-account-compilation-option/network.json
+++ b/test/configuration-tests/with-account-compilation-option/network.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../network.schema",
+    "devnet": true
+}

--- a/test/configuration-tests/with-disable-hint-compilation-option/network.json
+++ b/test/configuration-tests/with-disable-hint-compilation-option/network.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../network.schema",
+    "devnet": true
+}

--- a/test/general-tests/expect-error-on-compile/check.sh
+++ b/test/general-tests/expect-error-on-compile/check.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+CONTRACT_NAME=invalid_contract.cairo
+CONTRACT_PATH="contracts/$CONTRACT_NAME"
+
+cp "$(dirname "$0")/$CONTRACT_NAME" "$CONTRACT_PATH"
+
+echo "Testing rejection of compilation with correct message"
+npx hardhat starknet-compile "$CONTRACT_PATH" 2>&1 |
+    ../scripts/assert-contains.py "Unknown identifier 'openzeppelin.token.erc721.library.ERC721.nonexistent_method'"
+echo "Success"

--- a/test/general-tests/expect-error-on-compile/hardhat.config.ts
+++ b/test/general-tests/expect-error-on-compile/hardhat.config.ts
@@ -1,0 +1,12 @@
+import "../dist/src/index.js";
+
+module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
+    networks: {
+        devnet: {
+            url: "http://127.0.0.1:5050"
+        }
+    }
+};

--- a/test/general-tests/expect-error-on-compile/invalid_contract.cairo
+++ b/test/general-tests/expect-error-on-compile/invalid_contract.cairo
@@ -1,0 +1,13 @@
+// unknown identifier
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from openzeppelin.token.erc721.library import ERC721
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+) {
+    ERC721.nonexistent_method();
+    return ();
+}

--- a/test/general-tests/expect-error-on-compile/network.json
+++ b/test/general-tests/expect-error-on-compile/network.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../network.schema",
+    "devnet": true
+}


### PR DESCRIPTION
## Usage related changes

- Close #207 

## Development related changes

- Use custom error where not already present (one place had HardhatPluginError used instead of StarknetPluginError due to simultaneous development on two branches)
- Add a test which asserts compilation error content.
- Add two missing network.json files and made network.json a compulsory part of each test case (through a check in test.sh).
- Format test.sh

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [x] Linked issues which this PR resolves
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
