### PR TITLE
Add predefined network for Testnet 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ module.exports = {
 
 you can use it by calling `npx hardhat starknet-deploy --starknet-network myNetwork`.
 
-The Alpha networks and integrated Devnet are available by default, you don't need to define them in the config file; just pass:
+The AlphaGoerli networks and integrated Devnet are available by default, you don't need to define them in the config file; just pass:
 
--   `--starknet-network alpha` or `--starknet-network alpha-goerli` for Alpha Testnet (on Goerli)
+-   `--starknet-network alphaGoerli` or `--starknet-network alpha-goerli` for AlphaGoerli Testnet (on Goerli)
 -   `--starknet-network alpha-mainnet` for Alpha Mainnet
 -   `--starknet-network integrated-devnet` for integrated Devnet
 
@@ -123,7 +123,7 @@ npx hardhat starknet-verify [--starknet-network <NAME>] [--path <PATH>] [<DEPEND
 
 Queries [Voyager](https://voyager.online/) to [verify the contract](https://voyager.online/verifyContract) deployed at `<CONTRACT_ADDRESS>` using the source files at `<PATH>` and any number of `<DEPENDENCY_PATH>`.
 
-Like in the previous command, this plugin relies on `--starknet-network`, but will default to 'alpha' network in case this parameter is not passed.
+Like in the previous command, this plugin relies on `--starknet-network`, but will default to 'alphaGoerli' network in case this parameter is not passed.
 
 The verifier expects `<COMPILER_VERSION>` to be passed on request. Supported compiler versions are listed [here](https://voyager.online/verifyContract) in the dropdown menu.
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,22 +16,22 @@ export const CAIRO_CLI_DOCKER_REPOSITORY_WITH_TAG = `${CAIRO_CLI_DOCKER_REPOSITO
 export const ACCOUNT_ARTIFACTS_DIR = "account-contract-artifacts";
 
 export const ALPHA_TESTNET = "alpha-goerli";
-export const ALPHA_TESTNET_TWO = "alpha-goerli2";
-export const ALPHA_TESTNET_INTERNALLY = "alpha";
-export const ALPHA_TESTNET_TWO_INTERNALLY = "alpha2";
+export const ALPHA_TESTNET_2 = "alpha-goerli2";
+export const ALPHA_TESTNET_INTERNALLY = "alphaGoerli";
+export const ALPHA_TESTNET_2_INTERNALLY = "alphaGoerli2";
 export const ALPHA_MAINNET = "alpha-mainnet";
 export const ALPHA_MAINNET_INTERNALLY = "alphaMainnet";
 export const DEFAULT_STARKNET_NETWORK = ALPHA_TESTNET_INTERNALLY;
 export const ALPHA_URL = "https://alpha4.starknet.io";
-export const ALPHA_URL_TWO = "https://alpha4-2.starknet.io";
+export const ALPHA_GOERLI_URL_2 = "https://alpha4-2.starknet.io";
 export const ALPHA_MAINNET_URL = "https://alpha-mainnet.starknet.io";
 export const INTEGRATED_DEVNET = "integrated-devnet";
 export const INTEGRATED_DEVNET_INTERNALLY = "integratedDevnet";
 
 export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";
 export const VOYAGER_GOERLI_VERIFIED_URL = "https://goerli.voyager.online/contract/";
-export const VOYAGER_GOERLI_TWO_CONTRACT_API_URL = "https://goerli-2.voyager.online/api/contract";
-export const VOYAGER_GOERLI_TWO_VERIFIED_URL = "https://goerli-2.voyager.online/contract/";
+export const VOYAGER_GOERLI_2_CONTRACT_API_URL = "https://goerli-2.voyager.online/api/contract";
+export const VOYAGER_GOERLI_2_VERIFIED_URL = "https://goerli-2.voyager.online/contract/";
 export const VOYAGER_MAINNET_CONTRACT_API_URL = "https://voyager.online/api/contract/";
 export const VOYAGER_MAINNET_VERIFIED_URL = "https://voyager.online/contract/";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,17 +16,22 @@ export const CAIRO_CLI_DOCKER_REPOSITORY_WITH_TAG = `${CAIRO_CLI_DOCKER_REPOSITO
 export const ACCOUNT_ARTIFACTS_DIR = "account-contract-artifacts";
 
 export const ALPHA_TESTNET = "alpha-goerli";
+export const ALPHA_TESTNET_TWO = "alpha-goerli2";
 export const ALPHA_TESTNET_INTERNALLY = "alpha";
+export const ALPHA_TESTNET_TWO_INTERNALLY = "alpha2";
 export const ALPHA_MAINNET = "alpha-mainnet";
 export const ALPHA_MAINNET_INTERNALLY = "alphaMainnet";
 export const DEFAULT_STARKNET_NETWORK = ALPHA_TESTNET_INTERNALLY;
 export const ALPHA_URL = "https://alpha4.starknet.io";
+export const ALPHA_URL_TWO = "https://alpha4-2.starknet.io";
 export const ALPHA_MAINNET_URL = "https://alpha-mainnet.starknet.io";
 export const INTEGRATED_DEVNET = "integrated-devnet";
 export const INTEGRATED_DEVNET_INTERNALLY = "integratedDevnet";
 
 export const VOYAGER_GOERLI_CONTRACT_API_URL = "https://goerli.voyager.online/api/contract/";
 export const VOYAGER_GOERLI_VERIFIED_URL = "https://goerli.voyager.online/contract/";
+export const VOYAGER_GOERLI_TWO_CONTRACT_API_URL = "https://goerli-2.voyager.online/api/contract";
+export const VOYAGER_GOERLI_TWO_VERIFIED_URL = "https://goerli-2.voyager.online/contract/";
 export const VOYAGER_MAINNET_CONTRACT_API_URL = "https://voyager.online/api/contract/";
 export const VOYAGER_MAINNET_VERIFIED_URL = "https://voyager.online/contract/";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,16 @@ import {
     CAIRO_CLI_DEFAULT_DOCKER_IMAGE_TAG,
     CAIRO_CLI_DOCKER_REPOSITORY,
     ALPHA_URL,
+    ALPHA_URL_TWO,
     ALPHA_MAINNET_URL,
     VOYAGER_GOERLI_CONTRACT_API_URL,
     VOYAGER_MAINNET_CONTRACT_API_URL,
     DEFAULT_STARKNET_NETWORK,
     INTEGRATED_DEVNET_URL,
     VOYAGER_GOERLI_VERIFIED_URL,
-    VOYAGER_MAINNET_VERIFIED_URL
+    VOYAGER_MAINNET_VERIFIED_URL,
+    VOYAGER_GOERLI_TWO_CONTRACT_API_URL,
+    VOYAGER_GOERLI_TWO_VERIFIED_URL
 } from "./constants";
 import {
     getAccountPath,
@@ -117,6 +120,15 @@ extendConfig((config: HardhatConfig) => {
             ALPHA_URL,
             VOYAGER_GOERLI_CONTRACT_API_URL,
             VOYAGER_GOERLI_VERIFIED_URL,
+            StarknetChainId.TESTNET
+        );
+    }
+
+    if (!config.networks.alpha2) {
+        config.networks.alpha2 = getDefaultHttpNetworkConfig(
+            ALPHA_URL_TWO,
+            VOYAGER_GOERLI_TWO_CONTRACT_API_URL,
+            VOYAGER_GOERLI_TWO_VERIFIED_URL,
             StarknetChainId.TESTNET
         );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
     CAIRO_CLI_DEFAULT_DOCKER_IMAGE_TAG,
     CAIRO_CLI_DOCKER_REPOSITORY,
     ALPHA_URL,
-    ALPHA_URL_TWO,
+    ALPHA_GOERLI_URL_2,
     ALPHA_MAINNET_URL,
     VOYAGER_GOERLI_CONTRACT_API_URL,
     VOYAGER_MAINNET_CONTRACT_API_URL,
@@ -20,8 +20,8 @@ import {
     INTEGRATED_DEVNET_URL,
     VOYAGER_GOERLI_VERIFIED_URL,
     VOYAGER_MAINNET_VERIFIED_URL,
-    VOYAGER_GOERLI_TWO_CONTRACT_API_URL,
-    VOYAGER_GOERLI_TWO_VERIFIED_URL
+    VOYAGER_GOERLI_2_CONTRACT_API_URL,
+    VOYAGER_GOERLI_2_VERIFIED_URL
 } from "./constants";
 import {
     getAccountPath,
@@ -115,8 +115,8 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
 
 // add url to alpha network
 extendConfig((config: HardhatConfig) => {
-    if (!config.networks.alpha) {
-        config.networks.alpha = getDefaultHttpNetworkConfig(
+    if (!config.networks.alphaGoerli) {
+        config.networks.alphaGoerli = getDefaultHttpNetworkConfig(
             ALPHA_URL,
             VOYAGER_GOERLI_CONTRACT_API_URL,
             VOYAGER_GOERLI_VERIFIED_URL,
@@ -124,11 +124,11 @@ extendConfig((config: HardhatConfig) => {
         );
     }
 
-    if (!config.networks.alpha2) {
-        config.networks.alpha2 = getDefaultHttpNetworkConfig(
-            ALPHA_URL_TWO,
-            VOYAGER_GOERLI_TWO_CONTRACT_API_URL,
-            VOYAGER_GOERLI_TWO_VERIFIED_URL,
+    if (!config.networks.alphaGoerli2) {
+        config.networks.alphaGoerli2 = getDefaultHttpNetworkConfig(
+            ALPHA_GOERLI_URL_2,
+            VOYAGER_GOERLI_2_CONTRACT_API_URL,
+            VOYAGER_GOERLI_2_VERIFIED_URL,
             StarknetChainId.TESTNET
         );
     }

--- a/src/starknet_cli_legacy.py
+++ b/src/starknet_cli_legacy.py
@@ -63,11 +63,13 @@ from starkware.starkware_utils.error_handling import StarkErrorCode
 
 NETWORKS = {
     "alpha-goerli": "alpha4.starknet.io",
+    "alpha-goerli2": "alpha4-2.starknet.io",
     "alpha-mainnet": "alpha-mainnet.starknet.io",
 }
 
 CHAIN_IDS = {
     "alpha-goerli": StarknetChainId.TESTNET.value,
+    "alpha-goerli2": StarknetChainId.TESTNET.value,
     "alpha-mainnet": StarknetChainId.MAINNET.value,
 }
 

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -65,7 +65,7 @@ declare module "hardhat/types/config" {
 
     export interface NetworksConfig {
         alphaGoerli: HttpNetworkConfig;
-        alphaGoerli2: HttpNetworkConfig,
+        alphaGoerli2: HttpNetworkConfig;
         alphaMainnet: HttpNetworkConfig;
         integratedDevnet: HardhatNetworkConfig;
     }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -64,8 +64,8 @@ declare module "hardhat/types/config" {
     }
 
     export interface NetworksConfig {
-        alpha: HttpNetworkConfig;
-        alpha2: HttpNetworkConfig,
+        alphaGoerli: HttpNetworkConfig;
+        alphaGoerli2: HttpNetworkConfig,
         alphaMainnet: HttpNetworkConfig;
         integratedDevnet: HardhatNetworkConfig;
     }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -65,6 +65,7 @@ declare module "hardhat/types/config" {
 
     export interface NetworksConfig {
         alpha: HttpNetworkConfig;
+        alpha2: HttpNetworkConfig,
         alphaMainnet: HttpNetworkConfig;
         integratedDevnet: HardhatNetworkConfig;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,8 @@ import {
     ALPHA_MAINNET_INTERNALLY,
     ALPHA_TESTNET,
     ALPHA_TESTNET_INTERNALLY,
+    ALPHA_TESTNET_TWO,
+    ALPHA_TESTNET_TWO_INTERNALLY,
     DEFAULT_STARKNET_ACCOUNT_PATH,
     INTEGRATED_DEVNET,
     INTEGRATED_DEVNET_INTERNALLY
@@ -146,6 +148,8 @@ export function getNetwork<N extends NetworkConfig>(
         networkName = ALPHA_MAINNET_INTERNALLY;
     } else if (isTestnet(networkName)) {
         networkName = ALPHA_TESTNET_INTERNALLY;
+    } else if (isTestnetTwo(networkName)) {
+        networkName = ALPHA_TESTNET_TWO_INTERNALLY;
     } else if (isStarknetDevnet(networkName)) {
         networkName = INTEGRATED_DEVNET_INTERNALLY;
     }
@@ -167,6 +171,10 @@ export function getNetwork<N extends NetworkConfig>(
 
 function isTestnet(networkName: string): boolean {
     return networkName === ALPHA_TESTNET || networkName === ALPHA_TESTNET_INTERNALLY;
+}
+
+function isTestnetTwo(networkName: string): boolean {
+    return networkName === ALPHA_TESTNET_TWO || networkName === ALPHA_TESTNET_TWO_INTERNALLY;
 }
 
 function isMainnet(networkName: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,8 +12,8 @@ import {
     ALPHA_MAINNET_INTERNALLY,
     ALPHA_TESTNET,
     ALPHA_TESTNET_INTERNALLY,
-    ALPHA_TESTNET_TWO,
-    ALPHA_TESTNET_TWO_INTERNALLY,
+    ALPHA_TESTNET_2,
+    ALPHA_TESTNET_2_INTERNALLY,
     DEFAULT_STARKNET_ACCOUNT_PATH,
     INTEGRATED_DEVNET,
     INTEGRATED_DEVNET_INTERNALLY
@@ -149,7 +149,7 @@ export function getNetwork<N extends NetworkConfig>(
     } else if (isTestnet(networkName)) {
         networkName = ALPHA_TESTNET_INTERNALLY;
     } else if (isTestnetTwo(networkName)) {
-        networkName = ALPHA_TESTNET_TWO_INTERNALLY;
+        networkName = ALPHA_TESTNET_2_INTERNALLY;
     } else if (isStarknetDevnet(networkName)) {
         networkName = INTEGRATED_DEVNET_INTERNALLY;
     }
@@ -174,7 +174,7 @@ function isTestnet(networkName: string): boolean {
 }
 
 function isTestnetTwo(networkName: string): boolean {
-    return networkName === ALPHA_TESTNET_TWO || networkName === ALPHA_TESTNET_TWO_INTERNALLY;
+    return networkName === ALPHA_TESTNET_2 || networkName === ALPHA_TESTNET_2_INTERNALLY;
 }
 
 function isMainnet(networkName: string): boolean {

--- a/test/configuration-tests/with-cli-network/hardhat.config.ts
+++ b/test/configuration-tests/with-cli-network/hardhat.config.ts
@@ -2,7 +2,7 @@ import "@shardlabs/starknet-hardhat-plugin";
 
 module.exports = {
     starknet: {
-        network: "alpha"
+        network: "alphaGoerli2"
     },
     networks: {
         devnet: {

--- a/test/configuration-tests/with-networks/check.ts
+++ b/test/configuration-tests/with-networks/check.ts
@@ -1,4 +1,4 @@
-import { assertContains } from "../../utils/utils";
+import { assertContains, ensureEnvVar } from "../../utils/utils";
 import path from "path";
 import { readFileSync } from "fs";
 import {
@@ -43,3 +43,12 @@ process.env.NETWORK = invalidNetwork;
 execution = hardhatStarknetTest("--no-compile test/contract-factory-test.ts".split(" "), true);
 assertContains(execution.stderr, expected);
 console.log("Success");
+
+console.log("Testing with alpha-goerli2 config network");
+process.env.NETWORK = "alpha-goerli2";
+const network = ensureEnvVar("NETWORK");
+hardhatStarknetDeploy(
+    `starknet-artifacts/contracts/contract.cairo --starknet-network ${network} --inputs 10`.split(
+        " "
+    )
+);

--- a/test/configuration-tests/with-networks/check.ts
+++ b/test/configuration-tests/with-networks/check.ts
@@ -1,4 +1,4 @@
-import { assertContains, ensureEnvVar } from "../../utils/utils";
+import { assertContains } from "../../utils/utils";
 import path from "path";
 import { readFileSync } from "fs";
 import {
@@ -45,10 +45,8 @@ assertContains(execution.stderr, expected);
 console.log("Success");
 
 console.log("Testing with alpha-goerli2 config network");
-process.env.NETWORK = "alpha-goerli2";
-const network = ensureEnvVar("NETWORK");
 hardhatStarknetDeploy(
-    `starknet-artifacts/contracts/contract.cairo --starknet-network ${network} --inputs 10`.split(
+    "starknet-artifacts/contracts/contract.cairo --starknet-network alpha-goerli2 --inputs 10".split(
         " "
     )
 );

--- a/test/configuration-tests/with-networks/invalid-cli-network.txt
+++ b/test/configuration-tests/with-networks/invalid-cli-network.txt
@@ -1,2 +1,2 @@
 Error in plugin Starknet: Invalid network provided in starknet-network: foo.
-Valid hardhat networks: hardhat, localhost, devnet, alpha, alphaMainnet, integratedDevnet
+Valid hardhat networks: hardhat, localhost, devnet, alpha, alpha2, alphaMainnet, integratedDevnet

--- a/test/configuration-tests/with-networks/invalid-cli-network.txt
+++ b/test/configuration-tests/with-networks/invalid-cli-network.txt
@@ -1,2 +1,2 @@
 Error in plugin Starknet: Invalid network provided in starknet-network: foo.
-Valid hardhat networks: hardhat, localhost, devnet, alpha, alpha2, alphaMainnet, integratedDevnet
+Valid hardhat networks: hardhat, localhost, devnet, alphaGoerli, alphaGoerli2, alphaMainnet, integratedDevnet

--- a/test/configuration-tests/with-networks/invalid-config-network.txt
+++ b/test/configuration-tests/with-networks/invalid-config-network.txt
@@ -1,4 +1,4 @@
 Error in plugin Starknet: Invalid network provided in starknet.network in hardhat.config: foo.
-Valid hardhat networks: hardhat, localhost, devnet, alpha, alpha2, alphaMainnet, integratedDevnet
+Valid hardhat networks: hardhat, localhost, devnet, alphaGoerli, alphaGoerli2, alphaMainnet, integratedDevnet
 
 For more info run Hardhat with --show-stack-traces

--- a/test/configuration-tests/with-networks/invalid-config-network.txt
+++ b/test/configuration-tests/with-networks/invalid-config-network.txt
@@ -1,4 +1,4 @@
 Error in plugin Starknet: Invalid network provided in starknet.network in hardhat.config: foo.
-Valid hardhat networks: hardhat, localhost, devnet, alpha, alphaMainnet, integratedDevnet
+Valid hardhat networks: hardhat, localhost, devnet, alpha, alpha2, alphaMainnet, integratedDevnet
 
 For more info run Hardhat with --show-stack-traces

--- a/test/general-tests/account-test/network.json
+++ b/test/general-tests/account-test/network.json
@@ -1,5 +1,5 @@
 {
     "$schema": "../../network.schema",
-    "alpha": true,
+    "alphaGoerli2": true,
     "devnet": true
 }

--- a/test/general-tests/declare-test/network.json
+++ b/test/general-tests/declare-test/network.json
@@ -1,5 +1,5 @@
 {
     "$schema": "../../network.schema",
-    "alpha": true,
+    "alphaGoerli2": true,
     "devnet": true
 }

--- a/test/general-tests/plain/network.json
+++ b/test/general-tests/plain/network.json
@@ -1,5 +1,5 @@
 {
     "$schema": "../../network.schema",
-    "alpha": true,
+    "alphaGoerli2": true,
     "devnet": true
 }

--- a/test/general-tests/starknet-verify/check.ts
+++ b/test/general-tests/starknet-verify/check.ts
@@ -31,6 +31,8 @@ console.log("Sleeping to allow Voyager to register the verification");
 exec("sleep 15s");
 
 (async () => {
-    const { data } = await axios.get(`https://goerli-2.voyager.online/api/contract/${address}/code`);
+    const { data } = await axios.get(
+        `https://goerli-2.voyager.online/api/contract/${address}/code`
+    );
     assertEqual(data.abiVerified, "true", "Contract is not verified");
 })();

--- a/test/general-tests/starknet-verify/check.ts
+++ b/test/general-tests/starknet-verify/check.ts
@@ -31,6 +31,6 @@ console.log("Sleeping to allow Voyager to register the verification");
 exec("sleep 15s");
 
 (async () => {
-    const { data } = await axios.get(`https://goerli.voyager.online/api/contract/${address}/code`);
+    const { data } = await axios.get(`https://goerli-2.voyager.online/api/contract/${address}/code`);
     assertEqual(data.abiVerified, "true", "Contract is not verified");
 })();

--- a/test/general-tests/starknet-verify/network.json
+++ b/test/general-tests/starknet-verify/network.json
@@ -1,4 +1,4 @@
 {
     "$schema": "../../network.schema",
-    "alpha": true
+    "alphaGoerli2": true
 }

--- a/test/network.schema
+++ b/test/network.schema
@@ -5,9 +5,6 @@
         "devnet": {
             "type": "boolean"
         },
-        "alphaGoerli": {
-            "type": "boolean"
-        },
         "alphaGoerli2": {
             "type": "boolean"
         },

--- a/test/network.schema
+++ b/test/network.schema
@@ -5,7 +5,10 @@
         "devnet": {
             "type": "boolean"
         },
-        "alpha": {
+        "alphaGoerli": {
+            "type": "boolean"
+        },
+        "alphaGoerli2": {
             "type": "boolean"
         },
         "integrated-devnet": {

--- a/test/venv-tests/with-venv-active/network.json
+++ b/test/venv-tests/with-venv-active/network.json
@@ -1,5 +1,5 @@
 {
     "$schema": "../../network.schema",
-    "alpha": true,
+    "alphaGoerli2": true,
     "devnet": true
 }

--- a/test/venv-tests/with-venv/network.json
+++ b/test/venv-tests/with-venv/network.json
@@ -1,5 +1,5 @@
 {
     "$schema": "../../network.schema",
-    "alpha": true,
+    "alphaGoerli2": true,
     "devnet": true
 }


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- Closes #247 
- Network for Testnet 2 can be specified as `alpha-goeli2` or `alpha2`

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->
- NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [x] Linked issues which this PR resolves
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
