### PR TITLE
Use node to run tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -72,7 +72,7 @@ function iterate_dir() {
         # check if test_case/check.ts exists
         if [ -f "$test_case/check.ts" ]; then
             # run the test
-            NETWORK="$network" npx mocha -r ts-node/register "$test_case/check.ts" && success=$((success + 1)) || echo "Test failed!"
+            NETWORK="$network" node -r ts-node/register "$test_case/check.ts" && success=$((success + 1)) || echo "Test failed!"
         fi
 
         rm -rf starknet-artifacts

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -72,7 +72,7 @@ function iterate_dir() {
         # check if test_case/check.ts exists
         if [ -f "$test_case/check.ts" ]; then
             # run the test
-            NETWORK="$network" node -r ts-node/register "$test_case/check.ts" && success=$((success + 1)) || echo "Test failed!"
+            NETWORK="$network" npx ts-node "$test_case/check.ts" && success=$((success + 1)) || echo "Test failed!"
         fi
 
         rm -rf starknet-artifacts

--- a/src/types.ts
+++ b/src/types.ts
@@ -770,7 +770,7 @@ export class StarknetContract {
         }
 
         if (decodedEvents.length === 0) {
-            const msg = `No events were decoded. You might be using a wrong contract. ${this.abiPath}`;
+            const msg = `No events were decoded. You might be using a wrong contract.\nABI used for decoding: ${this.abiPath}`;
             throw new StarknetPluginError(msg);
         }
         return decodedEvents;

--- a/src/types.ts
+++ b/src/types.ts
@@ -755,6 +755,7 @@ export class StarknetContract {
     async decodeEvents(events: starknet.Event[]): Promise<DecodedEvent[]> {
         const decodedEvents: DecodedEvent[] = [];
         for (const event of events) {
+            if (parseInt(event.from_address, 16) !== parseInt(this.address, 16)) continue;
             const rawEventData = event.data.map(BigInt).join(" ");
             // encoded event name guaranteed to be at index 0
             const eventSpecification = this.eventsSpecifications[event.keys[0]];
@@ -767,6 +768,10 @@ export class StarknetContract {
             decodedEvents.push({ name: eventSpecification.name, data: adapted });
         }
 
+        if (decodedEvents.length === 0) {
+            const msg = `No events were decoded. You might be using a wrong contract. ${this.abiPath}`;
+            throw new StarknetPluginError(msg);
+        }
         return decodedEvents;
     }
 }

--- a/test/configuration-tests/with-networks/check.ts
+++ b/test/configuration-tests/with-networks/check.ts
@@ -45,6 +45,7 @@ assertContains(execution.stderr, expected);
 console.log("Success");
 
 console.log("Testing with alpha-goerli2 config network");
+process.env.NETWORK = "alpha-goerli2";
 hardhatStarknetDeploy(
     "starknet-artifacts/contracts/contract.cairo --starknet-network alpha-goerli2 --inputs 10".split(
         " "

--- a/test/general-tests/cairo-migrate/check.ts
+++ b/test/general-tests/cairo-migrate/check.ts
@@ -11,7 +11,7 @@ copyFileSync(path.join(__dirname, contractName), contractPath);
 
 console.log("Testing migration of old cairo contract to a new one");
 // Migrate contract to new version.
-const execution = hardhatStarknetMigrate([contractPath], true);
+const execution = hardhatStarknetMigrate([contractPath]);
 assertContains(execution.stdout, newComment);
 
 // Migrate contract to new version with change content in place option.

--- a/test/general-tests/starknet-call/check.ts
+++ b/test/general-tests/starknet-call/check.ts
@@ -13,10 +13,8 @@ hardhatStarknetCompile(["contracts/contract.cairo"]);
 const output = hardhatStarknetDeploy(
     `--starknet-network ${network} starknet-artifacts/contracts/contract.cairo/ --inputs 10`.split(
         " "
-    ),
-    true
+    )
 );
-console.log(output.stdout);
 
 const address = extractAddress(output.stdout, "Contract address: ");
 const prefix = path.join(__dirname);

--- a/test/general-tests/starknet-verify/check.ts
+++ b/test/general-tests/starknet-verify/check.ts
@@ -1,5 +1,9 @@
 import { assertEqual, ensureEnvVar, exec, extractAddress } from "../../utils/utils";
-import { hardhatStarknetCompile, hardhatStarknetDeploy } from "../../utils/cli-functions";
+import {
+    hardhatStarknetCompile,
+    hardhatStarknetDeploy,
+    hardhatStarknetVerify
+} from "../../utils/cli-functions";
 import axios from "axios";
 
 console.log(
@@ -24,8 +28,10 @@ console.log("Verifying contract at $address");
 console.log("Sleeping to allow Voyager to index the deployment");
 exec("sleep 1m");
 
-exec(
-    `npx hardhat starknet-verify --starknet-network ${network} --path ${mainContract} ${utilContract} --address ${address} --compiler-version 0.9.0 --license "No License (None)" --account-contract false`
+hardhatStarknetVerify(
+    `--starknet-network ${network} --path ${mainContract} ${utilContract} --address ${address} --compiler-version 0.9.0 --license "No License (None)"`.split(
+        " "
+    )
 );
 console.log("Sleeping to allow Voyager to register the verification");
 exec("sleep 15s");

--- a/test/integrated-devnet-tests/with-stderr-to-STDERR/check.ts
+++ b/test/integrated-devnet-tests/with-stderr-to-STDERR/check.ts
@@ -10,10 +10,7 @@ import { hardhatStarknetCompile, hardhatStarknetTest } from "../../utils/cli-fun
         "WARNING: Use these accounts and their keys ONLY for local testing. DO NOT use them on mainnet or other live networks because you will LOSE FUNDS.";
 
     hardhatStarknetCompile(["contracts/contract.cairo"]);
-    const execution = hardhatStarknetTest(
-        "--no-compile test/integrated-devnet.test.ts".split(" "),
-        true
-    );
+    const execution = hardhatStarknetTest("--no-compile test/integrated-devnet.test.ts".split(" "));
     assertContains(execution.stderr, expectedWarning);
 
     // Checks if file logs/stderr.log exists and contains the expected warning string

--- a/test/utils/cli-functions.ts
+++ b/test/utils/cli-functions.ts
@@ -1,9 +1,13 @@
 import shell from "shelljs";
+import { assertEqual } from "./utils";
 
-const exec = (cmd: string, silent?: boolean) => {
+export function exec(cmd: string, silent?: boolean) {
     silent = silent || false;
-    return shell.exec(cmd, { silent: silent });
-};
+    const result = shell.exec(cmd, { silent: silent });
+    assertEqual(result.code, 0, `Command ${cmd} failed.\n${result.stderr}`);
+
+    return result;
+}
 
 export const hardhatStarknetCompile = (args: Array<string>, silent?: boolean) => {
     return exec(`npx hardhat starknet-compile ${args.join(" ")}`, silent);
@@ -39,6 +43,10 @@ export const hardhatStarknetRun = (args: Array<string>, silent?: boolean) => {
 
 export const hardhatStarknetTest = (args: Array<string>, silent?: boolean) => {
     return exec(`npx hardhat test ${args.join(" ")}`, silent);
+};
+
+export const hardhatStarknetVerify = (args: Array<string>, silent?: boolean) => {
+    return exec(`npx hardhat starknet-verify ${args.join(" ")}`, silent);
 };
 
 export const hardhatStarknetMigrate = (args: Array<string>, silent?: boolean) => {

--- a/test/utils/cli-functions.ts
+++ b/test/utils/cli-functions.ts
@@ -1,57 +1,59 @@
 import shell from "shelljs";
-import { assertEqual } from "./utils";
+import { assertEqual, assertNotEqual } from "./utils";
 
-export function exec(cmd: string, expectFailure?: boolean) {
-    expectFailure = expectFailure || false;
+export function exec(cmd: string, expectFailure = false) {
     const result = shell.exec(cmd, { silent: expectFailure });
+    const msg = `Command ${cmd} failed.\n${result.stderr}`;
     if (!expectFailure) {
-        assertEqual(result.code, 0, `Command ${cmd} failed.\n${result.stderr}`);
+        assertEqual(result.code, 0, msg);
+    } else {
+        assertNotEqual(result.code, 0, msg);
     }
 
     return result;
 }
 
-export const hardhatStarknetCompile = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetCompile = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat starknet-compile ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetDeploy = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetDeploy = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat starknet-deploy ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetInvoke = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetInvoke = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat starknet-invoke ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetCall = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetCall = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat starknet-call ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetEstimateFee = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetEstimateFee = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat starknet-estimate-fee ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetNewAccount = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetNewAccount = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat starknet-new-account ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetDeployAccount = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetDeployAccount = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat starknet-deploy-account ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetRun = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetRun = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat run ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetTest = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetTest = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat test ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetVerify = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetVerify = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat starknet-verify ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetMigrate = (args: Array<string>, expectFailure?: boolean) => {
+export const hardhatStarknetMigrate = (args: Array<string>, expectFailure = false) => {
     return exec(`npx hardhat migrate ${args.join(" ")}`, expectFailure);
 };
 

--- a/test/utils/cli-functions.ts
+++ b/test/utils/cli-functions.ts
@@ -1,56 +1,58 @@
 import shell from "shelljs";
 import { assertEqual } from "./utils";
 
-export function exec(cmd: string, silent?: boolean) {
-    silent = silent || false;
-    const result = shell.exec(cmd, { silent: silent });
-    assertEqual(result.code, 0, `Command ${cmd} failed.\n${result.stderr}`);
+export function exec(cmd: string, expectFailure?: boolean) {
+    expectFailure = expectFailure || false;
+    const result = shell.exec(cmd, { silent: expectFailure });
+    if (!expectFailure) {
+        assertEqual(result.code, 0, `Command ${cmd} failed.\n${result.stderr}`);
+    }
 
     return result;
 }
 
-export const hardhatStarknetCompile = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat starknet-compile ${args.join(" ")}`, silent);
+export const hardhatStarknetCompile = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat starknet-compile ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetDeploy = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat starknet-deploy ${args.join(" ")}`, silent);
+export const hardhatStarknetDeploy = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat starknet-deploy ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetInvoke = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat starknet-invoke ${args.join(" ")}`, silent);
+export const hardhatStarknetInvoke = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat starknet-invoke ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetCall = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat starknet-call ${args.join(" ")}`, silent);
+export const hardhatStarknetCall = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat starknet-call ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetEstimateFee = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat starknet-estimate-fee ${args.join(" ")}`, silent);
+export const hardhatStarknetEstimateFee = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat starknet-estimate-fee ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetNewAccount = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat starknet-new-account ${args.join(" ")}`, silent);
+export const hardhatStarknetNewAccount = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat starknet-new-account ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetDeployAccount = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat starknet-deploy-account ${args.join(" ")}`, silent);
+export const hardhatStarknetDeployAccount = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat starknet-deploy-account ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetRun = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat run ${args.join(" ")}`, silent);
+export const hardhatStarknetRun = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat run ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetTest = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat test ${args.join(" ")}`, silent);
+export const hardhatStarknetTest = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat test ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetVerify = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat starknet-verify ${args.join(" ")}`, silent);
+export const hardhatStarknetVerify = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat starknet-verify ${args.join(" ")}`, expectFailure);
 };
 
-export const hardhatStarknetMigrate = (args: Array<string>, silent?: boolean) => {
-    return exec(`npx hardhat migrate ${args.join(" ")}`, silent);
+export const hardhatStarknetMigrate = (args: Array<string>, expectFailure?: boolean) => {
+    return exec(`npx hardhat migrate ${args.join(" ")}`, expectFailure);
 };
 
 export const hardhatStarknetPluginVersion = () => {

--- a/test/utils/deploy-funded-account.ts
+++ b/test/utils/deploy-funded-account.ts
@@ -21,10 +21,16 @@ export async function deployFundedAccount(url = DEVNET_URL) {
         .address;
 
     console.log(`Funding account ${accountAddress} on ${network}.`);
-    await axios.post(`${url}/mint`, {
+    const data = JSON.stringify({
         address: accountAddress,
-        amount: 1000000000000000000n,
+        amount: 10 ** 18,
         lite: true
+    });
+
+    await axios.post(`${url}/mint`, data, {
+        headers: {
+            "Content-Type": "application/json"
+        }
     });
 
     // Deploying funded account on the network

--- a/test/utils/deploy-funded-account.ts
+++ b/test/utils/deploy-funded-account.ts
@@ -21,17 +21,13 @@ export async function deployFundedAccount(url = DEVNET_URL) {
         .address;
 
     console.log(`Funding account ${accountAddress} on ${network}.`);
-    const data = JSON.stringify({
+    const data = {
         address: accountAddress,
         amount: 10 ** 18,
         lite: true
-    });
+    };
 
-    await axios.post(`${url}/mint`, data, {
-        headers: {
-            "Content-Type": "application/json"
-        }
-    });
+    await axios.post(`${url}/mint`, data);
 
     // Deploying funded account on the network
     hardhatStarknetDeployAccount(args);


### PR DESCRIPTION
- Avoids 0 passing tests message by mocha
- Removes flag for account-contract from `starknet-verify` test
- Update exec function to break on exit with status code different from 0

## Usage related changes

<!-- How the changes from this PR affect users. -->

-   NA

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   Tests are launched by `node` instead of `mocha`

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.sh`)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
