### PR TITLE
Support new chain ID for Alpha Goerli 2

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,13 @@ export enum TransactionHashPrefix {
     DEPLOY = "110386840629113",
     INVOKE = "115923154332517"
 }
+
+export enum StarknetChainId {
+    MAINNET = "0x534e5f4d41494e",
+    TESTNET = "0x534e5f474f45524c49",
+    TESTNET2 = "0x534e5f474f45524c4932"
+}
+
 export const PREFIX_TRANSACTION = "StarkNet Transaction";
 
 export const TRANSACTION_VERSION = BigInt(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ import {
     VOYAGER_GOERLI_VERIFIED_URL,
     VOYAGER_MAINNET_VERIFIED_URL,
     VOYAGER_GOERLI_2_CONTRACT_API_URL,
-    VOYAGER_GOERLI_2_VERIFIED_URL
+    VOYAGER_GOERLI_2_VERIFIED_URL,
+    StarknetChainId
 } from "./constants";
 import {
     getAccountPath,
@@ -60,7 +61,6 @@ import {
 } from "./extend-utils";
 import { DevnetUtils } from "./devnet-utils";
 import { ExternalServer } from "./external-server";
-import { StarknetChainId } from "starknet/constants";
 
 exitHook(() => {
     ExternalServer.cleanAll();
@@ -130,7 +130,7 @@ extendConfig((config: HardhatConfig) => {
             ALPHA_GOERLI_URL_2,
             VOYAGER_GOERLI_2_CONTRACT_API_URL,
             VOYAGER_GOERLI_2_VERIFIED_URL,
-            StarknetChainId.TESTNET
+            StarknetChainId.TESTNET2
         );
     }
 

--- a/src/starknet_cli_legacy.py
+++ b/src/starknet_cli_legacy.py
@@ -69,8 +69,8 @@ NETWORKS = {
 
 CHAIN_IDS = {
     "alpha-goerli": StarknetChainId.TESTNET.value,
-    "alpha-goerli2": StarknetChainId.TESTNET.value,
-    "alpha-mainnet": StarknetChainId.MAINNET.value,
+    "alpha-goerli2": StarknetChainId.TESTNET2.value,
+    "alpha-mainnet": StarknetChainId.MAINNET.value
 }
 
 FEE_MARGIN_OF_ESTIMATION = 1.1

--- a/src/starknet_cli_legacy.py
+++ b/src/starknet_cli_legacy.py
@@ -69,7 +69,7 @@ NETWORKS = {
 
 CHAIN_IDS = {
     "alpha-goerli": StarknetChainId.TESTNET.value,
-    "alpha-goerli2": StarknetChainId.TESTNET2.value,
+    "alpha-goerli2": StarknetChainId.TESTNET.value, # Should be changed to StarknetChainId.TESTNET2.value when adapting 0.10.3.
     "alpha-mainnet": StarknetChainId.MAINNET.value
 }
 

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -20,7 +20,7 @@ import {
 import { Account, ArgentAccount, OpenZeppelinAccount } from "./account";
 import { Transaction, TransactionReceipt, Block, TransactionTrace } from "./starknet-types";
 import { HardhatNetworkConfig, NetworkConfig } from "hardhat/types/config";
-import { StarknetChainId } from "starknet/constants";
+import { StarknetChainId } from "./constants";
 
 type StarknetConfig = {
     dockerizedVersion?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,14 +16,14 @@ import {
     ALPHA_TESTNET_2_INTERNALLY,
     DEFAULT_STARKNET_ACCOUNT_PATH,
     INTEGRATED_DEVNET,
-    INTEGRATED_DEVNET_INTERNALLY
+    INTEGRATED_DEVNET_INTERNALLY,
+    StarknetChainId
 } from "./constants";
 import * as path from "path";
 import * as fs from "fs";
 import { glob } from "glob";
 import { promisify } from "util";
 import { StringMap } from "./types";
-import { StarknetChainId } from "starknet/constants";
 
 const globPromise = promisify(glob);
 /**


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   Closes #263 
-   Adds new `enum` with new chain ID added for alpha goerli2
-   `"alpha-goerli2": StarknetChainId.TESTNET.value,` on `starknet_cli_legacy.py` Should be changed to `StarknetChainId.TESTNET2.value` when adapting 0.10.3.

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Linked issues which this PR resolves
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
