### PR TITLE
 Add timeout to devnet & integrated-devnet requests

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,7 @@ export const VOYAGER_MAINNET_VERIFIED_URL = "https://voyager.online/contract/";
 
 export const CHECK_STATUS_TIMEOUT = 5000; // ms
 export const CHECK_STATUS_RECOVER_TIMEOUT = 10000; // ms
+export const REQUEST_TIMEOUT = 30000; // ms
 
 export const LEN_SUFFIX = "_len";
 

--- a/src/external-server/external-server.ts
+++ b/src/external-server/external-server.ts
@@ -4,6 +4,7 @@ import { ChildProcess } from "child_process";
 import { StarknetPluginError } from "../starknet-plugin-error";
 import { IntegratedDevnetLogger } from "./integrated-devnet-logger";
 import { StringMap } from "../types";
+import { REQUEST_TIMEOUT } from "../constants";
 
 function sleep(amountMillis: number): Promise<void> {
     return new Promise((resolve) => {
@@ -161,7 +162,10 @@ export abstract class ExternalServer {
         await this.ensureStarted();
 
         try {
-            const response = await axios.post<T>(this.url, data);
+            const response = await axios.post<T>(this.url, data, {
+                timeout: REQUEST_TIMEOUT,
+                timeoutErrorMessage: "Request timed out"
+            });
             return response.data;
         } catch (error) {
             const parent = error instanceof Error && error;


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   Adds timeout to requests in `devnet-utils.ts` and `externatl-server.ts`
-   Have 30 seconds as a request timeout (so far, the default axios was 0)
-   Closes #167 

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [x] Linked issues which this PR resolves
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
