### PR TITLE
#287 TypeRoots - only from this dir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
         "strictNullChecks": false,
         "declaration": true,
         "module": "commonjs",
-        "noImplicitOverride": true
+        "noImplicitOverride": true,
+        "typeRoots": ["./node_modules/@types"]
     },
     "include": ["./src", "config.json", "contract-artifacts/**/*.json"]
 }


### PR DESCRIPTION
## Usage related changes

This only limits the scole of lookup for `@types` to current directory's `node_modules`.

## Development related changes

This only limits the scole of lookup for `@types` to current directory's `node_modules`.

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
    -   [ ] If `src/type-extensions.ts` was changed, updated the line number referencing this file in the `## API` section of README.md
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)

Closes #287