### PR TITLE
Support L1-L2 mock messaging

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "CAIRO_LANG": "0.10.3",
-    "STARKNET_DEVNET": "0.4.2"
+    "STARKNET_DEVNET": "0.4.4"
 }

--- a/scripts/setup-venv.sh
+++ b/scripts/setup-venv.sh
@@ -16,6 +16,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 if [ "$TEST_SUBDIR" == "venv-tests" ]; then
+    CFLAGS=-I`brew --prefix gmp`/include LDFLAGS=-L`brew --prefix gmp`/lib pip3 install fastecdsa
     which "$VENV/bin/starknet" || pip3 install cairo-lang=="$(cat /tmp/cairo-lang-version)"
     echo "starknet at: $(which starknet)"
     echo "starknet version: $(starknet --version)"

--- a/scripts/setup-venv.sh
+++ b/scripts/setup-venv.sh
@@ -13,10 +13,10 @@ echo "python version: $(python --version)"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     export HOMEBREW_NO_INSTALL_CLEANUP=1
     brew ls --versions gmp || brew install gmp
+    CFLAGS=-I`brew --prefix gmp`/include LDFLAGS=-L`brew --prefix gmp`/lib pip3 install fastecdsa
 fi
 
 if [ "$TEST_SUBDIR" == "venv-tests" ]; then
-    CFLAGS=-I`brew --prefix gmp`/include LDFLAGS=-L`brew --prefix gmp`/lib pip3 install fastecdsa
     which "$VENV/bin/starknet" || pip3 install cairo-lang=="$(cat /tmp/cairo-lang-version)"
     echo "starknet at: $(which starknet)"
     echo "starknet version: $(starknet --version)"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-EXAMPLE_REPO_BRANCH="l1-l2-test"
+EXAMPLE_REPO_BRANCH="plugin"
 if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$EXAMPLE_REPO_BRANCH" != "plugin" ]]; then
     echo "Invalid example repo branch: $EXAMPLE_REPO_BRANCH"
     exit 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-EXAMPLE_REPO_BRANCH="plugin"
+EXAMPLE_REPO_BRANCH="l1-l2-test"
 if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$EXAMPLE_REPO_BRANCH" != "plugin" ]]; then
     echo "Invalid example repo branch: $EXAMPLE_REPO_BRANCH"
     exit 1

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -5,6 +5,8 @@ import { Devnet, HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { Block, L2ToL1Message } from "./starknet-types";
 import { REQUEST_TIMEOUT } from "./constants";
+import { hash } from "starknet";
+import { numericToHexString } from "./utils";
 
 interface L1ToL2Message {
     address: string;
@@ -34,6 +36,28 @@ export interface FlushResponse {
 export interface LoadL1MessagingContractResponse {
     address: string;
     l1_provider: string;
+}
+
+export interface L1ToL2MockTxRequest {
+    l2_contract_address: string;
+    l1_contract_address: string;
+    entry_point_selector: string;
+    payload: Array<number>;
+    nonce: string;
+}
+
+export interface L1ToL2MockTxResponse {
+    transaction_hash: string;
+}
+
+export interface L2ToL1MockTxRequest {
+    l2_contract_address: string;
+    l1_contract_address: string;
+    payload: Array<number>;
+}
+
+export interface L2ToL1MockTxResponse {
+    message_hash: string;
 }
 
 export interface SetTimeResponse {
@@ -102,6 +126,48 @@ Make sure you really want to interact with Devnet and that it is running and ava
 
         const response = await this.requestHandler<LoadL1MessagingContractResponse>(
             "/postman/load_l1_messaging_contract",
+            "POST",
+            body
+        );
+        return response.data;
+    }
+
+    public async sendMessageToL2(
+        l2ContractAddress: string,
+        funcionName: string,
+        l1ContractAddress: string,
+        payload: number[],
+        nonce: number
+    ) {
+        const body = {
+            l2_contract_address: l1ContractAddress,
+            entry_point_selector: hash.getSelectorFromName(funcionName),
+            l1_contract_address: l2ContractAddress,
+            payload: payload.map((item) => numericToHexString(item)),
+            nonce: numericToHexString(nonce)
+        };
+
+        const response = await this.requestHandler<L1ToL2MockTxResponse>(
+            "/postman/send_message_to_l2",
+            "POST",
+            body
+        );
+        return response.data;
+    }
+
+    public async sendMessageToL1(
+        l2ContractAddress: string,
+        l1ContractAddress: string,
+        payload: number[]
+    ) {
+        const body = {
+            l2_contract_address: l2ContractAddress,
+            l1_contract_address: l1ContractAddress,
+            payload: payload.map((item) => numericToHexString(item))
+        };
+
+        const response = await this.requestHandler<L2ToL1MockTxResponse>(
+            "/postman/consume_message_from_l2",
             "POST",
             body
         );

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -140,9 +140,9 @@ Make sure you really want to interact with Devnet and that it is running and ava
         nonce: number
     ) {
         const body = {
-            l2_contract_address: l1ContractAddress,
+            l2_contract_address: l2ContractAddress,
             entry_point_selector: hash.getSelectorFromName(funcionName),
-            l1_contract_address: l2ContractAddress,
+            l1_contract_address: l1ContractAddress,
             payload: payload.map((item) => numericToHexString(item)),
             nonce: numericToHexString(nonce)
         };

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -155,7 +155,7 @@ Make sure you really want to interact with Devnet and that it is running and ava
         return response.data;
     }
 
-    public async sendMessageToL1(
+    public async consumeMessageFromL2(
         l2ContractAddress: string,
         l1ContractAddress: string,
         payload: number[]

--- a/src/types/devnet.ts
+++ b/src/types/devnet.ts
@@ -38,8 +38,8 @@ export interface Devnet {
 
     /**
      * Sends a mock tx from L1 to L2 without running L1.
-     * @param {string} l2ContractAddress - Adress of the L2 contract.
-     * @param {string} l1ContractAddress - Adress of the L1 contract.
+     * @param {string} l2ContractAddress - Address of the L2 contract.
+     * @param {string} l1ContractAddress - Address of the L1 contract.
      * @param {string} functionName - Function name for entry point selector.
      * @param {Array<string>} payload - Payload to send to the L2 network.
      * @param {string} nonce - Nonce value
@@ -55,12 +55,12 @@ export interface Devnet {
 
     /**
      * Sends a mock tx from L2 to L1
-     * @param {string} l2ContractAddress - Adress of the L2 contract.
-     * @param {string} l1ContractAddress - Adress of the L1 contract.
+     * @param {string} l2ContractAddress - Address of the L2 contract.
+     * @param {string} l1ContractAddress - Address of the L1 contract.
      * @param {Array<number>} payload - Payload to send to the L1 network.
      * @returns Message hash
      */
-    sendMessageToL1: (
+    consumeMessageFromL2: (
         l2ContractAddress: string,
         l1ContractAddress: string,
         payload: Array<number>

--- a/src/types/devnet.ts
+++ b/src/types/devnet.ts
@@ -3,7 +3,9 @@ import {
     IncreaseTimeResponse,
     LoadL1MessagingContractResponse,
     SetTimeResponse,
-    PredeployedAccount
+    PredeployedAccount,
+    L1ToL2MockTxResponse,
+    L2ToL1MockTxResponse
 } from "../devnet-utils";
 import { Block } from "../starknet-types";
 
@@ -33,6 +35,36 @@ export interface Devnet {
         address?: string,
         networkId?: string
     ) => Promise<LoadL1MessagingContractResponse>;
+
+    /**
+     * Sends a mock tx from L1 to L2 without running L1.
+     * @param {string} l2ContractAddress - Adress of the L2 contract.
+     * @param {string} l1ContractAddress - Adress of the L1 contract.
+     * @param {string} functionName - Function name for entry point selector.
+     * @param {Array<string>} payload - Payload to send to the L2 network.
+     * @param {string} nonce - Nonce value
+     * @returns Transaction hash
+     */
+    sendMessageToL2: (
+        l2ContractAddress: string,
+        l1ContractAddress: string,
+        functionName: string,
+        payload: Array<number>,
+        nonce: number
+    ) => Promise<L1ToL2MockTxResponse>;
+
+    /**
+     * Sends a mock tx from L2 to L1
+     * @param {string} l2ContractAddress - Adress of the L2 contract.
+     * @param {string} l1ContractAddress - Adress of the L1 contract.
+     * @param {Array<number>} payload - Payload to send to the L1 network.
+     * @returns Message hash
+     */
+    sendMessageToL1: (
+        l2ContractAddress: string,
+        l1ContractAddress: string,
+        payload: Array<number>
+    ) => Promise<L2ToL1MockTxResponse>;
 
     /**
      * Increases block time offset

--- a/src/types/devnet.ts
+++ b/src/types/devnet.ts
@@ -37,7 +37,7 @@ export interface Devnet {
     ) => Promise<LoadL1MessagingContractResponse>;
 
     /**
-     * Sends a mock tx from L1 to L2 without running L1.
+     * Sends a mock message from L1 to L2 without running L1.
      * @param {string} l2ContractAddress - Address of the L2 contract.
      * @param {string} functionName - Function name for entry point selector.
      * @param {string} l1ContractAddress - Address of the L1 contract.
@@ -54,7 +54,7 @@ export interface Devnet {
     ) => Promise<L1ToL2MockTxResponse>;
 
     /**
-     * Sends a mock tx from L2 to L1
+     * Sends a mock message from L2 to L1
      * @param {string} l2ContractAddress - Address of the L2 contract.
      * @param {string} l1ContractAddress - Address of the L1 contract.
      * @param {Array<number>} payload - Payload to send to the L1 network.

--- a/src/types/devnet.ts
+++ b/src/types/devnet.ts
@@ -39,16 +39,16 @@ export interface Devnet {
     /**
      * Sends a mock tx from L1 to L2 without running L1.
      * @param {string} l2ContractAddress - Address of the L2 contract.
-     * @param {string} l1ContractAddress - Address of the L1 contract.
      * @param {string} functionName - Function name for entry point selector.
+     * @param {string} l1ContractAddress - Address of the L1 contract.
      * @param {Array<string>} payload - Payload to send to the L2 network.
      * @param {string} nonce - Nonce value
      * @returns Transaction hash
      */
     sendMessageToL2: (
         l2ContractAddress: string,
-        l1ContractAddress: string,
         functionName: string,
+        l1ContractAddress: string,
         payload: Array<number>,
         nonce: number
     ) => Promise<L1ToL2MockTxResponse>;

--- a/www/docs/intro.md
+++ b/www/docs/intro.md
@@ -332,6 +332,15 @@ Exchanging messages between L1 ([Ganache](https://www.npmjs.com/package/ganache)
   });
 ```
 
+#### Mock message between L1 and L2
+
+To send mock messages between L1 and L2 the following two functions can be used. Detailed example can be found [here](https://github.com/Shard-Labs/starknet-hardhat-example/blob/master/test/postman.test.ts#170).
+
+```typescript
+starknet.devnet.sendMessageToL2(...); // Sends message to L2
+starknet.devnet.consumeMessageFromL2(...); // Sends message from L2 to L1
+```
+
 #### Restart
 
 Devnet can be restarted by calling `starknet.devnet.restart()`. All of the deployed contracts, blocks and storage updates will be restarted to the empty state.


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   Adds L1 to L2 mock endpoint on devnet `sendMessageToL1()` and `sendMessageToL2()`
-   Closes #292 

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   Fixes the issue ERROR: `Failed building wheel for fastecdsa` on `venv-test` for macos.

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Linked issues which this PR resolves
-   [x] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):https://github.com/Shard-Labs/starknet-hardhat-example/pull/88
    -   [x] Modified `test.sh` to use my example repo branch
    -   [x] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
