### PR TITLE
Contract tests

### DIFF
--- a/test/general-tests/account-test/hardhat.config.ts
+++ b/test/general-tests/account-test/hardhat.config.ts
@@ -8,7 +8,7 @@ module.exports = {
         integratedDevnet: {
             url: "http://127.0.0.1:5050",
             // testing with fork because alpha-goerli has the needed argent account contracts declared
-            // using integrated-devnet (in network.json) because spawning devnet is currently out of reach for invidiual tests
+            // using integrated-devnet (in network.json) because spawning devnet is currently out of reach for individual tests
             args: ["--seed", "42", "--fork-network", "alpha-goerli"]
         }
     }

--- a/test/general-tests/contract-test/check.ts
+++ b/test/general-tests/contract-test/check.ts
@@ -1,0 +1,5 @@
+import { hardhatStarknetCompile, hardhatStarknetTest } from "../../utils/cli-functions";
+
+hardhatStarknetCompile("contracts/contract.cairo contracts/util.cairo".split(" "));
+hardhatStarknetTest("--no-compile test/contract.test.ts".split(" "));
+hardhatStarknetTest("--no-compile test/contract-factory.test.ts".split(" "));

--- a/test/general-tests/contract-test/hardhat.config.ts
+++ b/test/general-tests/contract-test/hardhat.config.ts
@@ -1,0 +1,15 @@
+import "@shardlabs/starknet-hardhat-plugin";
+
+module.exports = {
+    starknet: {
+        network: process.env.NETWORK
+    },
+    networks: {
+        integratedDevnet: {
+            url: "http://127.0.0.1:5050",
+            // testing with fork because alpha-goerli has the needed argent account contracts declared
+            // using integrated-devnet (in network.json) because spawning devnet is currently out of reach for invidiual tests
+            args: ["--seed", "42", "--fork-network", "alpha-goerli"]
+        }
+    }
+};

--- a/test/general-tests/contract-test/hardhat.config.ts
+++ b/test/general-tests/contract-test/hardhat.config.ts
@@ -7,9 +7,7 @@ module.exports = {
     networks: {
         integratedDevnet: {
             url: "http://127.0.0.1:5050",
-            // testing with fork because alpha-goerli has the needed argent account contracts declared
-            // using integrated-devnet (in network.json) because spawning devnet is currently out of reach for invidiual tests
-            args: ["--seed", "42", "--fork-network", "alpha-goerli"]
+            args: ["--seed", "42"]
         }
     }
 };

--- a/test/general-tests/contract-test/network.json
+++ b/test/general-tests/contract-test/network.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../network.schema",
+    "integrated-devnet": true
+}


### PR DESCRIPTION
Fixes #273

## Usage related changes

None

## Development related changes

Additional tests added for `StarknetContract` and `StarknetContractFactory`.

### New utils in **starknet-hardhat-example** repo to get pre-deployed accounts,

#### `function getPredeployedAccount()`
Returns `{Promise<PredeployedAccount>}`  details of a pre-deployed account.

#### `function getPredeployedOZAccount()`
Returns `{Promise<OpenZeppelinAccount>}` An OZAccount instance for a pre-deployed account.


## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [x] Linked issues which this PR resolves
-   [x] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   https://github.com/Shard-Labs/starknet-hardhat-example/pull/92
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
