### PR TITLE
Estimate deploy account fee

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-EXAMPLE_REPO_BRANCH="plugin"
+EXAMPLE_REPO_BRANCH="estimate-fee-deploy-account"
 if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$EXAMPLE_REPO_BRANCH" != "plugin" ]]; then
     echo "Invalid example repo branch: $EXAMPLE_REPO_BRANCH"
     exit 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-EXAMPLE_REPO_BRANCH="estimate-fee-deploy-account"
+EXAMPLE_REPO_BRANCH="plugin"
 if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$EXAMPLE_REPO_BRANCH" != "plugin" ]]; then
     echo "Invalid example repo branch: $EXAMPLE_REPO_BRANCH"
     exit 1

--- a/src/account.ts
+++ b/src/account.ts
@@ -833,7 +833,7 @@ export class ArgentAccount extends Account {
             contract_address_salt: this.salt,
             signature: bnToDecimalStringArray(signature || []),
             version: numericToHexString(QUERY_VERSION),
-            nonce: numericToHexString(0)
+            nonce
         };
 
         return await sendEstimateFeeTx(data);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -295,6 +295,7 @@ export interface DeployOptions {
 
 export interface DeployAccountOptions {
     maxFee?: Numeric;
+    overhead?: number;
 }
 
 export interface InvokeOptions {

--- a/www/docs/intro.md
+++ b/www/docs/intro.md
@@ -266,6 +266,15 @@ it("should work with tuples", async function () {
 
 ```typescript
 it("should estimate fee", async function () {
+    const account = await starknet.OpenZeppelinAccount.createAccount({
+      salt: "0x42",
+      privateKey: OZ_ACCOUNT_PRIVATE_KEY
+    });
+
+    // Fee estimation on account deployment
+    const estimatedFee = await account.estimateDeployAccountFee();
+    console.log("Estimated deploy account fee: ", estimatedFee);
+
     const contractFactory = await starknet.getContractFactory(
               "contract"
     );


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   The `estimateDeployAccountFee()` function can be used to obtain the account deployment fee.
-   Closes #298 

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [x] Linked issues which this PR resolves
-   [x] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):https://github.com/Shard-Labs/starknet-hardhat-example/pull/96
    -   [x] Modified `test.sh` to use my example repo branch
    -   [x] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
