### PR TITLE
fix: typo in docs

### DIFF
--- a/www/docs/intro.md
+++ b/www/docs/intro.md
@@ -625,7 +625,7 @@ pip install openzeppelin-cairo-contracts
 ```typescript
 paths: {
     // this directory contains the openzeppelin directory
-    cairoPaths: ["path/to/cairo_venv/lib/python3.8/site-packages"];
+    cairoPaths: ["path/to/cairo_venv/lib/python3.8/site-packages"],
 }
 ```
 


### PR DESCRIPTION
replace semi column by comma
