### PR TITLE
Pass Declare Nonce to Starknet CLI

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -434,6 +434,7 @@ export abstract class Account {
 
         const signature = this.getSignatures(messageHash);
         return contractFactory.declare({
+            nonce,
             signature,
             token: options.token,
             sender: this.address,

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -28,6 +28,7 @@ interface DeclareWrapperOptions {
     signature?: string[];
     token?: string;
     sender?: string;
+    nonce?: string;
 }
 
 interface InteractWrapperOptions {
@@ -161,6 +162,10 @@ export abstract class StarknetWrapper {
             throw new StarknetPluginError("No maxFee provided for declare tx");
         }
         prepared.push("--max_fee", options.maxFee);
+
+        if (options.nonce) {
+            prepared.push("--nonce", options.nonce);
+        }
 
         return prepared;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -372,7 +372,7 @@ export class StarknetContractFactory {
             maxFee: (options.maxFee || 0).toString(),
             token: options.token,
             signature: handleSignature(options.signature),
-            sender: options.sender
+            nonce: options.nonce?.toString()
         });
         if (executed.statusCode) {
             const msg = `Could not declare class: ${executed.stderr.toString()}`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -372,6 +372,7 @@ export class StarknetContractFactory {
             maxFee: (options.maxFee || 0).toString(),
             token: options.token,
             signature: handleSignature(options.signature),
+            sender: options.sender,
             nonce: options.nonce?.toString()
         });
         if (executed.statusCode) {


### PR DESCRIPTION
## Usage related changes

This PR fixes the following error when passing a custom nonce to a declare transaction via the `Account` class:

```
Signature (..., ...), is invalid, with respect to the public key ..., and the message hash ...
```

This would occur because the message hash with the custom nonce would be signed, while the transaction would be created with the current account nonce. This issue made it nearly impossible to submit multiple declare transactions at the same time.

## Checklist:

-   [X] Formatted the code
-   [X] No linter errors + tried to avoid introducing linter warnings
-   [X] Performed a self-review of the code
-   [X] Rebased to the last commit of the target branch (or merged it into my branch)
-   [X] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
