### PR TITLE
Declare return tx hash

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,13 +9,13 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-EXAMPLE_REPO_BRANCH="plugin-declare-return-tx-hash"
-if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$EXAMPLE_REPO_BRANCH" != "plugin-declare-return-tx-hash" ]]; then
+EXAMPLE_REPO_BRANCH="plugin"
+if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$EXAMPLE_REPO_BRANCH" != "plugin" ]]; then
     echo "Invalid example repo branch: $EXAMPLE_REPO_BRANCH"
     exit 1
 fi
 
-git clone -b "$EXAMPLE_REPO_BRANCH" --single-branch git@github.com:brilliantblocks/starknet-hardhat-example.git
+git clone -b "$EXAMPLE_REPO_BRANCH" --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
 cd starknet-hardhat-example
 git log -n 1
 npm ci

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,13 +9,13 @@ CONFIG_FILE_NAME="hardhat.config.ts"
 
 # setup example repo
 rm -rf starknet-hardhat-example
-EXAMPLE_REPO_BRANCH="plugin"
-if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$EXAMPLE_REPO_BRANCH" != "plugin" ]]; then
+EXAMPLE_REPO_BRANCH="plugin-declare-return-tx-hash"
+if [[ "$CIRCLE_BRANCH" == "master" ]] && [[ "$EXAMPLE_REPO_BRANCH" != "plugin-declare-return-tx-hash" ]]; then
     echo "Invalid example repo branch: $EXAMPLE_REPO_BRANCH"
     exit 1
 fi
 
-git clone -b "$EXAMPLE_REPO_BRANCH" --single-branch git@github.com:Shard-Labs/starknet-hardhat-example.git
+git clone -b "$EXAMPLE_REPO_BRANCH" --single-branch git@github.com:brilliantblocks/starknet-hardhat-example.git
 cd starknet-hardhat-example
 git log -n 1
 npm ci

--- a/src/account.ts
+++ b/src/account.ts
@@ -397,7 +397,7 @@ export abstract class Account {
      * Declare the contract class corresponding to the `contractFactory`
      * @param contractFactory
      * @param options
-     * @returns the hash of the declared class
+     * @returns transaction hash
      */
     public async declare(
         contractFactory: StarknetContractFactory,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -365,7 +365,7 @@ export class StarknetContractFactory {
     /**
      * Declare a contract class.
      * @param options optional arguments to class declaration
-     * @returns the class hash as a hex string
+     * @returns transaction hash as a hex string
      */
     async declare(options: DeclareOptions = {}): Promise<string> {
         const executed = await this.hre.starknetWrapper.declare({
@@ -382,19 +382,9 @@ export class StarknetContractFactory {
         }
 
         const executedOutput = executed.stdout.toString();
-        const classHash = extractClassHash(executedOutput);
         const txHash = extractTxHash(executedOutput);
 
-        return new Promise((resolve, reject) => {
-            iterativelyCheckStatus(
-                txHash,
-                this.hre.starknetWrapper,
-                () => resolve(classHash),
-                (error) => {
-                    reject(new StarknetPluginError(`Declare transaction ${txHash}: ${error}`));
-                }
-            );
-        });
+        return txHash;
     }
 
     handleConstructorArguments(constructorArguments: StringMap): string[] {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -384,7 +384,16 @@ export class StarknetContractFactory {
         const executedOutput = executed.stdout.toString();
         const txHash = extractTxHash(executedOutput);
 
-        return txHash;
+        return new Promise((resolve, reject) => {
+            iterativelyCheckStatus(
+                txHash,
+                this.hre.starknetWrapper,
+                () => resolve(txHash),
+                (error) => {
+                    reject(new StarknetPluginError(`Declare transaction ${txHash}: ${error}`));
+                }
+            );
+        });
     }
 
     handleConstructorArguments(constructorArguments: StringMap): string[] {

--- a/www/docs/intro.md
+++ b/www/docs/intro.md
@@ -218,10 +218,11 @@ describe("My Test", function () {
     // not compatible with accounts deployed with Starknet CLI
     const account = await starknet.OpenZeppelinAccount.getAccountFromAddress(...);
     const contractFactory = await starknet.getContractFactory("MyContract");
-    const classHash = await account.declare(contractFactory);  // class declaration
+    const txHash = await account.declare(contractFactory);  // class declaration
 
-    // two ways to obtain the class hash
-    expect(classHash).to.equal(await contractFactory.getClassHash());
+    // ensure that tx has been successful
+    const txReceipt = await starknet.getTransactionReceipt(txHash);
+    expect(txReceipt.status).to.equal("ACCEPTED_ON_L2" || "ACCEPTED_ON_L1");
 
     const constructorArgs = { initial_balance: 0 };
     const options = { maxFee: ... };
@@ -307,8 +308,13 @@ it("should estimate fee", async function () {
 it("should forward to the implementation contract", async function () {
     const implementationFactory = await starknet.getContractFactory("contract");
     const account = ...;
-    const implementationClassHash = await account.declare(implementationFactory);
+    const txHash = await account.declare(implementationFactory);
 
+    // ensure that tx has been successful
+    const txReceipt = await starknet.getTransactionReceipt(txHash);
+    expect(txReceipt.status).to.equal("ACCEPTED_ON_L2" || "ACCEPTED_ON_L1");
+
+    const implementationClassHash = await contractFactory.getClassHash()
     const proxyFactory = await starknet.getContractFactory("delegate_proxy");
     await account.declare(proxyFactory);
     const proxy = await account.deploy(proxyFactory, {

--- a/www/docs/intro.md
+++ b/www/docs/intro.md
@@ -219,10 +219,7 @@ describe("My Test", function () {
     const account = await starknet.OpenZeppelinAccount.getAccountFromAddress(...);
     const contractFactory = await starknet.getContractFactory("MyContract");
     const txHash = await account.declare(contractFactory);  // class declaration
-
-    // ensure that tx has been successful
-    const txReceipt = await starknet.getTransactionReceipt(txHash);
-    expect(txReceipt.status).to.equal("ACCEPTED_ON_L2" || "ACCEPTED_ON_L1");
+    const classHash = await contractFactory.getClassHash();
 
     const constructorArgs = { initial_balance: 0 };
     const options = { maxFee: ... };
@@ -309,12 +306,8 @@ it("should forward to the implementation contract", async function () {
     const implementationFactory = await starknet.getContractFactory("contract");
     const account = ...;
     const txHash = await account.declare(implementationFactory);
-
-    // ensure that tx has been successful
-    const txReceipt = await starknet.getTransactionReceipt(txHash);
-    expect(txReceipt.status).to.equal("ACCEPTED_ON_L2" || "ACCEPTED_ON_L1");
-
-    const implementationClassHash = await contractFactory.getClassHash()
+    const implementationClassHash = await implementationFactory.getClassHash();
+    
     const proxyFactory = await starknet.getContractFactory("delegate_proxy");
     await account.declare(proxyFactory);
     const proxy = await account.deploy(proxyFactory, {


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-  `declare()` now returns the tx instead of the class hash
- Now, the user needs to check the tx status for validating a successful declaration
- Closes #313 (breaking)

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   N/A

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [x] Linked issues which this PR resolves (#313)
-   [x] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/Shard-Labs/starknet-hardhat-example):
    -   https://github.com/Shard-Labs/starknet-hardhat-example/pull/103
    -   [x] Modified `test.sh` to use my example repo branch
    -   [x] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
